### PR TITLE
fix: use POST for nfts refresh, require type+value for offers traits

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -40,6 +40,25 @@ export class OpenSeaClient {
     return response.json() as Promise<T>
   }
 
+  async post<T>(path: string): Promise<T> {
+    const url = new URL(`${this.baseUrl}${path}`)
+
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "x-api-key": this.apiKey,
+      },
+    })
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new OpenSeaAPIError(response.status, body, path)
+    }
+
+    return response.json() as Promise<T>
+  }
+
   getDefaultChain(): string {
     return this.defaultChain
   }

--- a/src/commands/nfts.ts
+++ b/src/commands/nfts.ts
@@ -99,7 +99,7 @@ export function nftsCommand(
     .argument("<token-id>", "Token ID")
     .action(async (chain: string, contract: string, tokenId: string) => {
       const client = getClient()
-      await client.get(
+      await client.post(
         `/api/v2/chain/${chain}/contract/${contract}/nfts/${tokenId}/refresh`,
       )
       console.log(

--- a/src/commands/offers.ts
+++ b/src/commands/offers.ts
@@ -66,16 +66,16 @@ export function offersCommand(
     .command("traits")
     .description("Get trait offers for a collection")
     .argument("<collection>", "Collection slug")
-    .option("--type <type>", "Trait type")
-    .option("--value <value>", "Trait value")
+    .requiredOption("--type <type>", "Trait type (required)")
+    .requiredOption("--value <value>", "Trait value (required)")
     .option("--limit <limit>", "Number of results", "20")
     .option("--next <cursor>", "Pagination cursor")
     .action(
       async (
         collection: string,
         options: {
-          type?: string
-          value?: string
+          type: string
+          value: string
           limit: string
           next?: string
         },

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -120,7 +120,7 @@ class NFTsAPI {
     address: string,
     identifier: string,
   ): Promise<void> {
-    await this.client.get(
+    await this.client.post(
       `/api/v2/chain/${chain}/contract/${address}/nfts/${identifier}/refresh`,
     )
   }
@@ -191,9 +191,9 @@ class OffersAPI {
 
   async traits(
     collectionSlug: string,
-    options?: {
-      type?: string
-      value?: string
+    options: {
+      type: string
+      value: string
       limit?: number
       next?: string
     },
@@ -201,10 +201,10 @@ class OffersAPI {
     return this.client.get(
       `/api/v2/offers/collection/${collectionSlug}/traits`,
       {
-        type: options?.type,
-        value: options?.value,
-        limit: options?.limit,
-        next: options?.next,
+        type: options.type,
+        value: options.value,
+        limit: options.limit,
+        next: options.next,
       },
     )
   }


### PR DESCRIPTION
# fix: use POST for nfts refresh, require type+value for offers traits

## Summary

Fixes two bugs discovered during live API testing against `api.opensea.io/api/v2`:

1. **`nfts refresh`** was using `GET` but the API requires `POST` → returned 405 Method Not Allowed. Fixed in both CLI command and programmatic SDK.
2. **`offers traits`** had `--type` and `--value` as optional flags, but the API requires them → returned 400. Changed to `requiredOption` in the CLI and non-optional in the SDK type signature.

Added a `post<T>(path)` method to `OpenSeaClient` to support the refresh endpoint.

**All other endpoints were tested and confirmed working:** `collections get/list/stats/traits`, `nfts get/list-by-collection/list-by-contract/list-by-account/contract`, `listings all/best`, `offers all/collection/best-for-nft`, `events list/by-account/by-collection/by-nft`, `accounts get`.

## Review & Testing Checklist for Human

- [ ] The new `post` method does not accept a request body — confirm this is sufficient for the refresh endpoint (it worked in testing, but future POST endpoints may need a body parameter)
- [ ] The `post` method calls `response.json()` unconditionally — verify the refresh endpoint always returns a parseable JSON response (the CLI discards the return value, but the SDK `refresh()` types the return as `Promise<void>`)
- [ ] Verify `offers traits` with `--type` and `--value` returns results for a collection that actually has trait offers (our test returned empty `[]` for `tiny-dinos-eth` with `--type background --value blue`, which may just mean no offers exist for that trait)

**Test plan:**
```bash
npm install && npm run build
export OPENSEA_API_KEY=<your-key>

# Fixed endpoints:
node dist/cli.js nfts refresh ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1
node dist/cli.js offers traits tiny-dinos-eth --type background --value blue

# Verify offers traits rejects missing params:
node dist/cli.js offers traits tiny-dinos-eth  # should error about missing --type/--value
```

### Notes
- Confidence: **High** — small, focused fix confirmed working against live API
- [Link to Devin run](https://app.devin.ai/sessions/be782e7c5eb6417da262226ab4957831)
- Requested by: @CodySearsOS