### PR TITLE
docs: add examples and local development instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ opensea collections get boredapeyachtclub
 opensea --api-key your-api-key collections get boredapeyachtclub
 ```
 
-Get an API key at [docs.opensea.io](https://docs.opensea.io/).
+Get an API key at [docs.opensea.io](https://docs.opensea.io/reference/api-keys).
 
 ## CLI Usage
 
@@ -243,4 +243,4 @@ opensea accounts get 0xde7fce3a1cba4a705f299ce41d163017f165d666
 ## Requirements
 
 - Node.js >= 18.0.0
-- OpenSea API key ([get one here](https://docs.opensea.io/))
+- OpenSea API key ([get one here](https://docs.opensea.io/reference/api-keys))

--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ Or use without installing:
 npx opensea-cli collections get boredapeyachtclub
 ```
 
+## Local Development
+
+To test locally without publishing:
+
+```bash
+git clone https://github.com/ProjectOpenSea/opensea-cli.git
+cd opensea-cli
+npm install && npm run build
+export OPENSEA_API_KEY=your-api-key
+
+# Run directly with Node
+node dist/cli.js collections get tiny-dinos-eth
+
+# Or link globally to use the `opensea` command
+npm link
+opensea collections get tiny-dinos-eth
+```
+
 ## Authentication
 
 Set your API key via environment variable or flag:
@@ -73,7 +91,7 @@ opensea listings best-for-nft <collection> <token-id>
 opensea offers all <collection> [--limit <n>]
 opensea offers collection <collection> [--limit <n>]
 opensea offers best-for-nft <collection> <token-id>
-opensea offers traits <collection> [--type <type>] [--value <value>]
+opensea offers traits <collection> --type <type> --value <value>
 ```
 
 ### Events
@@ -122,6 +140,100 @@ Table - human-readable output:
 opensea --format table collections list --limit 5
 ```
 
+## Examples
+
+Here are real-world examples using the [tiny dinos](https://opensea.io/collection/tiny-dinos-eth) and [mfers](https://opensea.io/collection/mfers) collections:
+
+### Collections
+
+```bash
+# Get collection details
+opensea collections get tiny-dinos-eth
+
+# List collections with a limit
+opensea collections list --limit 2
+
+# Get collection stats (volume, floor price, etc.)
+opensea collections stats tiny-dinos-eth
+
+# Get collection traits
+opensea collections traits tiny-dinos-eth
+```
+
+### NFTs
+
+```bash
+# Get a specific NFT by chain/contract/token-id
+opensea nfts get ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1
+
+# List NFTs in a collection
+opensea nfts list-by-collection tiny-dinos-eth --limit 2
+
+# List NFTs by contract address
+opensea nfts list-by-contract ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 --limit 2
+
+# List NFTs owned by an account
+opensea nfts list-by-account ethereum 0xde7fce3a1cba4a705f299ce41d163017f165d666 --limit 2
+
+# Get contract details
+opensea nfts contract ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4
+
+# Refresh NFT metadata
+opensea nfts refresh ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1
+```
+
+### Listings
+
+```bash
+# Get all listings for a collection
+opensea listings all tiny-dinos-eth --limit 2
+
+# Get best (cheapest) listings
+opensea listings best tiny-dinos-eth --limit 2
+
+# Get the best listing for a specific NFT
+opensea listings best-for-nft mfers 3490
+```
+
+### Offers
+
+```bash
+# Get all offers for a collection
+opensea offers all tiny-dinos-eth --limit 2
+
+# Get collection offers
+opensea offers collection tiny-dinos-eth --limit 2
+
+# Get best offer for a specific NFT
+opensea offers best-for-nft tiny-dinos-eth 1
+
+# Get trait offers (type and value are required)
+opensea offers traits tiny-dinos-eth --type background --value blue --limit 2
+```
+
+### Events
+
+```bash
+# List recent events across all collections
+opensea events list --limit 2
+
+# Get events for a collection
+opensea events by-collection tiny-dinos-eth --limit 2
+
+# Get events for a specific NFT
+opensea events by-nft ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1 --limit 2
+
+# Get events for an account
+opensea events by-account 0xde7fce3a1cba4a705f299ce41d163017f165d666 --limit 2
+```
+
+### Accounts
+
+```bash
+# Get account details
+opensea accounts get 0xde7fce3a1cba4a705f299ce41d163017f165d666
+```
+
 ## Exit Codes
 
 - `0` - Success
@@ -131,4 +243,4 @@ opensea --format table collections list --limit 5
 ## Requirements
 
 - Node.js >= 18.0.0
-- OpenSea API key
+- OpenSea API key ([get one here](https://docs.opensea.io/))


### PR DESCRIPTION
# docs: add examples and local development instructions to README

## Summary

Documentation-only change to the README:

1. **Local Development section** — instructions for testing the CLI locally without publishing to npm (clone → build → run with `node dist/cli.js` or `npm link`)
2. **Examples section** — real-world CLI examples for all 6 command groups using `tiny-dinos-eth` and `mfers` collections, with actual contract addresses and wallet addresses
3. **Usage fix** — updated `offers traits` synopsis to show `--type` and `--value` as required flags (matching the code fix in PR #2)
4. **API key links** — both the Authentication section and Requirements section now link to `https://docs.opensea.io/reference/api-keys` (the specific API keys page, not the docs root)

## Review & Testing Checklist for Human

- [ ] Verify the Examples section doesn't feel redundant with the CLI Usage section above it — both document the same commands (one as syntax reference, one with real arguments). Consider whether consolidation would be cleaner.
- [ ] Spot-check that the example contract addresses and wallet addresses are correct for the collections referenced (tiny-dinos-eth contract `0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4`, owner `0xde7fce3a1cba4a705f299ce41d163017f165d666`).
- [ ] Confirm the API key link (`https://docs.opensea.io/reference/api-keys`) resolves correctly and is the preferred page to send users to.

### Notes
- Confidence: **High** — documentation-only change, no code modified
- [Link to Devin run](https://app.devin.ai/sessions/be782e7c5eb6417da262226ab4957831)
- Requested by: @CodySearsOS