### PR TITLE
ci: remove test step from publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,5 +17,4 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org/
       - run: npm install
-      - run: npm test
       - run: npm publish --provenance --access public


### PR DESCRIPTION
# ci: remove test step from publish workflow

## Summary

Removes the `npm test` step from the npm publish workflow. The repo currently has no test files, so `vitest run` exits with code 1 and blocks the publish pipeline from completing.

## Review & Testing Checklist for Human

- [ ] Verify you're OK with no test gate in the publish workflow — once tests are added to the repo, the test step should be re-added (or enforced via a separate PR-level CI workflow)
- [ ] Test by re-running the failed release publish, or creating a new release at https://github.com/ProjectOpenSea/opensea-cli/releases/new

### Notes
- The workflow only triggers on `release: [published]` events, so this change cannot be verified via PR CI
- Requested by: @CodySearsOS
- [Link to Devin run](https://app.devin.ai/sessions/3b4df94547e64e1da4157e264545b44a)