### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "OpenSea CLI - Query the OpenSea API from the command line or programmatically",
   "main": "dist/index.js",


### PR DESCRIPTION
# chore: bump opensea-cli version to 0.1.1

## Summary
- Bumped `package.json` version from `0.1.0` → `0.1.1`.

## Review & Testing Checklist for Human
- [ ] Confirm `0.1.1` is the correct next version for the just-merged README changes.
- [ ] If publishing/releasing, verify the release pipeline uses `package.json`’s version and no additional files (e.g. lockfile/changelog/tags) need updates.

### Notes
- Link to Devin run: https://app.devin.ai/sessions/ec2ce821272c4f2ab6e548633f062de5  
- Requested by: @CodySearsOS