### PR TITLE
fix: remove --provenance flag from npm publish for internal repo

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,6 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v6
@@ -17,4 +16,5 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org/
       - run: npm install
-      - run: npm publish --provenance --access public
+      # TODO: Re-enable --provenance and id-token:write permission once the repo is public
+      - run: npm publish --access public


### PR DESCRIPTION
## Summary

Removes the `--provenance` flag from `npm publish` in the release workflow. npm's sigstore provenance attestation only supports **public** GitHub repositories, and this repo has "internal" visibility, causing an E422 error during publishing:

```
Error verifying sigstore provenance bundle: Unsupported GitHub Actions source repository visibility: "internal"
```

Also removes the now-unused `id-token: write` permission (only required for provenance signing). A TODO comment is left to re-enable both once the repo is made public.

## Review & Testing Checklist for Human

- [ ] Verify no other workflow steps or jobs depend on the `id-token: write` permission
- [ ] After merging, trigger a new release and confirm that `npm publish` succeeds without `--provenance`

### Notes

- [Link to Devin run](https://app.devin.ai/sessions/21af944c7eac4676ac58a0c0dd1bfb53)
- Requested by @CodySearsOS