### PR TITLE
Rename package to @opensea/cli with stub redirect

### DIFF
--- a/.agents/rules.md
+++ b/.agents/rules.md
@@ -228,3 +228,7 @@ All CI checks must pass before merging.
 ### Publishing
 
 - GitHub Actions workflow (`.github/workflows/npm-publish.yml`) publishes to npm on GitHub release.
+- **Dual-package publishing**: The workflow publishes two packages:
+  1. `@opensea/cli` — the main package (from repo root).
+  2. `opensea-cli` — a stub redirect package (from `packages/opensea-cli-stub/`) that warns users to install `@opensea/cli`. The stub publish uses `continue-on-error: true` since its version rarely changes.
+- Auth uses OIDC via `id-token: write` + `setup-node` with `registry-url` + `--provenance` flag. No npm token secret needed.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,5 +16,11 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org/
+      # Publish @opensea/cli
       - run: npm install
       - run: npm publish --provenance --access public
+
+      # Publish opensea-cli stub (skip if version already exists)
+      - run: npm publish --provenance --access public
+        working-directory: packages/opensea-cli-stub
+        continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Query the OpenSea API from the command line or programmatically. Designed for bo
 ## Install
 
 ```bash
-npm install -g opensea-cli
+npm install -g @opensea/cli
 ```
 
 Or use without installing:
 
 ```bash
-npx opensea-cli collections get mfers
+npx @opensea/cli collections get mfers
 ```
 
 ## Authentication
@@ -128,7 +128,7 @@ opensea accounts get <address>
 Use as a TypeScript/JavaScript library:
 
 ```typescript
-import { OpenSeaCLI } from "opensea-cli"
+import { OpenSeaCLI } from "@opensea/cli"
 
 const client = new OpenSeaCLI({ apiKey: process.env.OPENSEA_API_KEY })
 
@@ -314,8 +314,8 @@ opensea accounts get 0x21130e908bba2d41b63fbca7caa131285b8724f8
 
 [version-badge]: https://img.shields.io/github/package-json/v/ProjectOpenSea/opensea-cli
 [version-link]: https://github.com/ProjectOpenSea/opensea-cli/releases
-[npm-badge]: https://img.shields.io/npm/v/opensea-cli?color=red
-[npm-link]: https://www.npmjs.com/package/opensea-cli
+[npm-badge]: https://img.shields.io/npm/v/@opensea/cli?color=red
+[npm-link]: https://www.npmjs.com/package/@opensea/cli
 [ci-badge]: https://github.com/ProjectOpenSea/opensea-cli/actions/workflows/ci.yml/badge.svg
 [ci-link]: https://github.com/ProjectOpenSea/opensea-cli/actions/workflows/ci.yml
 [license-badge]: https://img.shields.io/github/license/ProjectOpenSea/opensea-cli

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "opensea-cli",
-  "version": "0.1.5",
+  "name": "@opensea/cli",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opensea-cli",
-      "version": "0.1.5",
+      "name": "@opensea/cli",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "opensea-cli",
-  "version": "0.1.5",
+  "name": "@opensea/cli",
+  "version": "0.2.0",
   "type": "module",
   "description": "OpenSea CLI - Query the OpenSea API from the command line or programmatically",
   "main": "dist/index.js",

--- a/packages/opensea-cli-stub/package.json
+++ b/packages/opensea-cli-stub/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "opensea-cli",
+  "version": "0.2.0",
+  "description": "This package has moved to @opensea/cli",
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ProjectOpenSea/opensea-cli"
+  }
+}

--- a/packages/opensea-cli-stub/postinstall.js
+++ b/packages/opensea-cli-stub/postinstall.js
@@ -1,0 +1,11 @@
+console.warn(`
+╔═══════════════════════════════════════════════════════════════╗
+║                                                               ║
+║  You installed "opensea-cli" — this package has moved.        ║
+║                                                               ║
+║  Install the correct package:                                 ║
+║                                                               ║
+║    npm install -g @opensea/cli                                ║
+║                                                               ║
+╚═══════════════════════════════════════════════════════════════╝
+`)


### PR DESCRIPTION
## Summary
- Renames the npm package from `opensea-cli` to `@opensea/cli` (version 0.2.0)
- Adds a minimal stub package at `packages/opensea-cli-stub/` that publishes as `opensea-cli` and warns users to install `@opensea/cli` instead
- Updates the publish workflow to publish both packages on release
- Updates README install/import instructions and npm badge URLs

## Test plan
- [x] `npm run build` — builds successfully
- [x] `npm run test` — 113/113 tests pass
- [x] `npm run lint && npm run type-check` — clean
- [x] `node packages/opensea-cli-stub/postinstall.js` — prints redirect warning
- [x] `npm pack` from root — tarball named `@opensea/cli` (23.9 kB)
- [x] `npm pack` from stub — tarball named `opensea-cli` (420 B, just package.json + postinstall.js)
- [ ] Verify `@opensea` npm org exists before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
