### PR TITLE
docs: restructure README into concise overview with docs/ reference pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,14 @@ Query the OpenSea API from the command line or programmatically. Designed for bo
 
 - [Install](#install)
 - [Authentication](#authentication)
-- [CLI Usage](#cli-usage)
-  - [Global Options](#global-options)
-  - [Collections](#collections)
-  - [NFTs](#nfts)
-  - [Listings](#listings)
-  - [Offers](#offers)
-  - [Events](#events)
-  - [Search](#search)
-  - [Tokens](#tokens)
-  - [Swaps](#swaps)
-  - [Accounts](#accounts)
+- [Quick Start](#quick-start)
+- [Commands](#commands)
 - [Programmatic SDK](#programmatic-sdk)
 - [Output Formats](#output-formats)
-- [Examples](#examples)
 - [Exit Codes](#exit-codes)
 - [Requirements](#requirements)
 - [Development](#development)
+- [Docs](#docs)
 
 ## Install
 
@@ -59,147 +50,64 @@ opensea --api-key your-api-key collections get mfers
 
 Get an API key at [docs.opensea.io](https://docs.opensea.io/reference/api-keys).
 
-## CLI Usage
-
-### Global Options
-
-```
---api-key <key>     OpenSea API key (or set OPENSEA_API_KEY env var)
---chain <chain>     Default chain (default: ethereum)
---format <format>   Output format: json or table (default: json)
---base-url <url>    API base URL override (for testing against staging or proxies)
-```
-
-### Collections
+## Quick Start
 
 ```bash
-opensea collections get <slug>
-opensea collections list [--chain <chain>] [--order-by <field>] [--creator <username>] [--include-hidden] [--limit <n>] [--next <cursor>]
-opensea collections stats <slug>
-opensea collections traits <slug>
+# Get collection details
+opensea collections get mfers
+
+# Get floor price and volume stats
+opensea collections stats mfers
+
+# List NFTs in a collection
+opensea nfts list-by-collection mfers --limit 5
+
+# Get best listings
+opensea listings best mfers --limit 5
+
+# Search across OpenSea
+opensea search collections "cool cats"
+
+# Get trending tokens
+opensea tokens trending --limit 5
+
+# Human-readable table output
+opensea --format table collections stats mfers
 ```
 
-`--order-by` values: `created_date`, `one_day_change`, `seven_day_volume`, `seven_day_change`, `num_owners`, `market_cap`
+## Commands
 
-### NFTs
+| Command | Description |
+|---|---|
+| `collections` | Get, list, stats, and traits for NFT collections |
+| `nfts` | Get, list, refresh metadata, and contract details for NFTs |
+| `listings` | Get all, best, or best-for-nft listings |
+| `offers` | Get all, collection, best-for-nft, and trait offers |
+| `events` | List marketplace events (sales, transfers, mints, etc.) |
+| `search` | Search collections, NFTs, tokens, and accounts |
+| `tokens` | Get trending tokens, top tokens, and token details |
+| `swaps` | Get swap quotes for token trading |
+| `accounts` | Get account details |
 
-```bash
-opensea nfts get <chain> <contract> <token-id>
-opensea nfts list-by-collection <slug> [--limit <n>] [--next <cursor>]
-opensea nfts list-by-contract <chain> <contract> [--limit <n>] [--next <cursor>]
-opensea nfts list-by-account <chain> <address> [--limit <n>] [--next <cursor>]
-opensea nfts refresh <chain> <contract> <token-id>
-opensea nfts contract <chain> <address>
-```
+Global options: `--api-key`, `--chain` (default: ethereum), `--format` (json/table), `--base-url`
 
-### Listings
-
-```bash
-opensea listings all <collection> [--limit <n>] [--next <cursor>]
-opensea listings best <collection> [--limit <n>] [--next <cursor>]
-opensea listings best-for-nft <collection> <token-id>
-```
-
-### Offers
-
-```bash
-opensea offers all <collection> [--limit <n>] [--next <cursor>]
-opensea offers collection <collection> [--limit <n>] [--next <cursor>]
-opensea offers best-for-nft <collection> <token-id>
-opensea offers traits <collection> --type <type> --value <value> [--limit <n>] [--next <cursor>]
-```
-
-### Events
-
-```bash
-opensea events list [--event-type <type>] [--after <timestamp>] [--before <timestamp>] [--chain <chain>] [--limit <n>] [--next <cursor>]
-opensea events by-account <address> [--event-type <type>] [--chain <chain>] [--limit <n>] [--next <cursor>]
-opensea events by-collection <slug> [--event-type <type>] [--limit <n>] [--next <cursor>]
-opensea events by-nft <chain> <contract> <token-id> [--event-type <type>] [--limit <n>] [--next <cursor>]
-```
-
-Event types: `sale`, `transfer`, `mint`, `listing`, `offer`, `trait_offer`, `collection_offer` ([details](docs/events.md))
-
-### Search
-
-```bash
-opensea search collections <query> [--chains <chains>] [--limit <n>]
-opensea search nfts <query> [--collection <slug>] [--chains <chains>] [--limit <n>]
-opensea search tokens <query> [--chain <chain>] [--limit <n>]
-opensea search accounts <query> [--limit <n>]
-```
-
-### Tokens
-
-```bash
-opensea tokens trending [--chains <chains>] [--limit <n>] [--cursor <cursor>]
-opensea tokens top [--chains <chains>] [--limit <n>] [--cursor <cursor>]
-opensea tokens get <chain> <address>
-```
-
-### Swaps
-
-```bash
-opensea swaps quote --from-chain <chain> --from-address <address> --to-chain <chain> --to-address <address> --quantity <quantity> --address <address> [--slippage <slippage>] [--recipient <recipient>]
-```
-
-### Accounts
-
-```bash
-opensea accounts get <address>
-```
-
-> All list commands support cursor-based pagination. See [docs/pagination.md](docs/pagination.md) for details.
+Full command reference with all options and flags: [docs/cli-reference.md](docs/cli-reference.md)
 
 ## Programmatic SDK
-
-Use as a TypeScript/JavaScript library:
 
 ```typescript
 import { OpenSeaCLI, OpenSeaAPIError } from "@opensea/cli"
 
 const client = new OpenSeaCLI({ apiKey: process.env.OPENSEA_API_KEY })
 
-// Collections
 const collection = await client.collections.get("mfers")
-const stats = await client.collections.stats("mfers")
-
-// NFTs
 const { nfts } = await client.nfts.listByCollection("mfers", { limit: 5 })
-
-// Listings & Offers
 const { listings } = await client.listings.best("mfers", { limit: 10 })
-const { offers } = await client.offers.collection("mfers", { limit: 10 })
-
-// Events
 const { asset_events } = await client.events.byCollection("mfers", {
   eventType: "sale",
 })
-
-// Tokens
 const { tokens } = await client.tokens.trending({ chains: ["base"], limit: 5 })
-const tokenDetails = await client.tokens.get("base", "0x123...")
-
-// Search
-const collections = await client.search.collections("mfers", { limit: 5 })
-const nftResults = await client.search.nfts("cool cat", { limit: 5 })
-const tokenResults = await client.search.tokens("usdc", { chain: "base" })
-const accounts = await client.search.accounts("vitalik", { limit: 5 })
-
-// Swaps
-const { quote, transactions } = await client.swaps.quote({
-  fromChain: "base",
-  fromAddress: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
-  toChain: "base",
-  toAddress: "0x3ec2156d4c0a9cbdab4a016633b7bcf6a8d68ea2",
-  quantity: "1000000",
-  address: "0x21130e908bba2d41b63fbca7caa131285b8724f8",
-})
-
-// Accounts
-const account = await client.accounts.get(
-  "0x21130e908bba2d41b63fbca7caa131285b8724f8",
-)
+const results = await client.search.collections("mfers", { limit: 5 })
 
 // Error handling
 try {
@@ -229,152 +137,6 @@ Table - human-readable output:
 opensea --format table collections list --limit 5
 ```
 
-## Examples
-
-Here are real-world examples using the [tiny dinos](https://opensea.io/collection/tiny-dinos-eth) and [mfers](https://opensea.io/collection/mfers) collections:
-
-### Collections
-
-```bash
-# Get collection details
-opensea collections get tiny-dinos-eth
-
-# List collections with a limit
-opensea collections list --limit 2
-
-# Get collection stats (volume, floor price, etc.)
-opensea collections stats tiny-dinos-eth
-
-# Get collection traits
-opensea collections traits tiny-dinos-eth
-```
-
-### NFTs
-
-```bash
-# Get a specific NFT by chain/contract/token-id
-opensea nfts get ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1
-
-# List NFTs in a collection
-opensea nfts list-by-collection tiny-dinos-eth --limit 2
-
-# List NFTs by contract address
-opensea nfts list-by-contract ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 --limit 2
-
-# List NFTs owned by an account
-opensea nfts list-by-account ethereum 0x21130e908bba2d41b63fbca7caa131285b8724f8 --limit 2
-
-# Get contract details
-opensea nfts contract ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4
-
-# Refresh NFT metadata
-opensea nfts refresh ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1
-```
-
-### Listings
-
-```bash
-# Get all listings for a collection
-opensea listings all tiny-dinos-eth --limit 2
-
-# Get best (cheapest) listings
-opensea listings best tiny-dinos-eth --limit 2
-
-# Get the best listing for a specific NFT
-opensea listings best-for-nft mfers 3490
-```
-
-### Offers
-
-```bash
-# Get all offers for a collection
-opensea offers all tiny-dinos-eth --limit 2
-
-# Get collection offers
-opensea offers collection tiny-dinos-eth --limit 2
-
-# Get best offer for a specific NFT
-opensea offers best-for-nft tiny-dinos-eth 1
-
-# Get trait offers (type and value are required)
-opensea offers traits tiny-dinos-eth --type background --value blue --limit 2
-```
-
-### Events
-
-```bash
-# List recent events across all collections
-opensea events list --limit 2
-
-# Get events for a collection
-opensea events by-collection tiny-dinos-eth --limit 2
-
-# Get events for a specific NFT
-opensea events by-nft ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1 --limit 2
-
-# Get events for an account
-opensea events by-account 0x21130e908bba2d41b63fbca7caa131285b8724f8 --limit 2
-```
-
-### Search
-
-```bash
-# Search for collections
-opensea search collections mfers
-
-# Search for NFTs
-opensea search nfts "cool cat" --limit 5
-
-# Search for NFTs within a specific collection
-opensea search nfts "rare" --collection tiny-dinos-eth --limit 5
-
-# Search for tokens/currencies
-opensea search tokens eth --limit 5
-
-# Search for tokens on a specific chain
-opensea search tokens usdc --chain base --limit 5
-
-# Search for accounts
-opensea search accounts vitalik --limit 5
-```
-
-### Tokens
-
-```bash
-# Get trending tokens
-opensea tokens trending --limit 2
-
-# Get trending tokens on a specific chain
-opensea tokens trending --chains base --limit 2
-
-# Get top tokens by 24-hour volume
-opensea tokens top --limit 2
-
-# Get top tokens on a specific chain
-opensea tokens top --chains base --limit 2
-
-# Get details for a specific token (DebtReliefBot on Base)
-opensea tokens get base 0x3ec2156d4c0a9cbdab4a016633b7bcf6a8d68ea2
-```
-
-### Swaps
-
-```bash
-# Get a swap quote for USDC to DRB on Base
-opensea swaps quote \
-  --from-chain base --from-address 0x833589fcd6edb6e08f4c7c32d4f71b54bda02913 \
-  --to-chain base --to-address 0x3ec2156d4c0a9cbdab4a016633b7bcf6a8d68ea2 \
-  --quantity 1000000 \
-  --address 0x21130e908bba2d41b63fbca7caa131285b8724f8
-```
-
-### Accounts
-
-```bash
-# Get account details
-opensea accounts get 0x21130e908bba2d41b63fbca7caa131285b8724f8
-```
-
 ## Exit Codes
 
 - `0` - Success
@@ -397,6 +159,16 @@ npm run lint            # Lint with Biome
 npm run format          # Format with Biome
 npm run type-check      # TypeScript type checking
 ```
+
+## Docs
+
+| Document | Description |
+|---|---|
+| [CLI Reference](docs/cli-reference.md) | Full command reference with all options and flags |
+| [Examples](docs/examples.md) | Real-world usage examples for every command |
+| [SDK Reference](docs/sdk.md) | Full programmatic SDK API with all methods |
+| [Pagination](docs/pagination.md) | Cursor-based pagination patterns for CLI and SDK |
+| [Event Types](docs/events.md) | Event type values and filtering |
 
 [version-badge]: https://img.shields.io/github/package-json/v/ProjectOpenSea/opensea-cli
 [version-link]: https://github.com/ProjectOpenSea/opensea-cli/releases

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,93 @@
+# CLI Reference
+
+Full command reference for all `opensea` CLI commands.
+
+## Global Options
+
+```
+--api-key <key>     OpenSea API key (or set OPENSEA_API_KEY env var)
+--chain <chain>     Default chain (default: ethereum)
+--format <format>   Output format: json or table (default: json)
+--base-url <url>    API base URL override (for testing against staging or proxies)
+```
+
+## Collections
+
+```bash
+opensea collections get <slug>
+opensea collections list [--chain <chain>] [--order-by <field>] [--creator <username>] [--include-hidden] [--limit <n>] [--next <cursor>]
+opensea collections stats <slug>
+opensea collections traits <slug>
+```
+
+`--order-by` values: `created_date`, `one_day_change`, `seven_day_volume`, `seven_day_change`, `num_owners`, `market_cap`
+
+## NFTs
+
+```bash
+opensea nfts get <chain> <contract> <token-id>
+opensea nfts list-by-collection <slug> [--limit <n>] [--next <cursor>]
+opensea nfts list-by-contract <chain> <contract> [--limit <n>] [--next <cursor>]
+opensea nfts list-by-account <chain> <address> [--limit <n>] [--next <cursor>]
+opensea nfts refresh <chain> <contract> <token-id>
+opensea nfts contract <chain> <address>
+```
+
+## Listings
+
+```bash
+opensea listings all <collection> [--limit <n>] [--next <cursor>]
+opensea listings best <collection> [--limit <n>] [--next <cursor>]
+opensea listings best-for-nft <collection> <token-id>
+```
+
+## Offers
+
+```bash
+opensea offers all <collection> [--limit <n>] [--next <cursor>]
+opensea offers collection <collection> [--limit <n>] [--next <cursor>]
+opensea offers best-for-nft <collection> <token-id>
+opensea offers traits <collection> --type <type> --value <value> [--limit <n>] [--next <cursor>]
+```
+
+## Events
+
+```bash
+opensea events list [--event-type <type>] [--after <timestamp>] [--before <timestamp>] [--chain <chain>] [--limit <n>] [--next <cursor>]
+opensea events by-account <address> [--event-type <type>] [--chain <chain>] [--limit <n>] [--next <cursor>]
+opensea events by-collection <slug> [--event-type <type>] [--limit <n>] [--next <cursor>]
+opensea events by-nft <chain> <contract> <token-id> [--event-type <type>] [--limit <n>] [--next <cursor>]
+```
+
+Event types: `sale`, `transfer`, `mint`, `listing`, `offer`, `trait_offer`, `collection_offer` ([details](events.md))
+
+## Search
+
+```bash
+opensea search collections <query> [--chains <chains>] [--limit <n>]
+opensea search nfts <query> [--collection <slug>] [--chains <chains>] [--limit <n>]
+opensea search tokens <query> [--chain <chain>] [--limit <n>]
+opensea search accounts <query> [--limit <n>]
+```
+
+## Tokens
+
+```bash
+opensea tokens trending [--chains <chains>] [--limit <n>] [--cursor <cursor>]
+opensea tokens top [--chains <chains>] [--limit <n>] [--cursor <cursor>]
+opensea tokens get <chain> <address>
+```
+
+## Swaps
+
+```bash
+opensea swaps quote --from-chain <chain> --from-address <address> --to-chain <chain> --to-address <address> --quantity <quantity> --address <address> [--slippage <slippage>] [--recipient <recipient>]
+```
+
+## Accounts
+
+```bash
+opensea accounts get <address>
+```
+
+> All list commands support cursor-based pagination. See [pagination.md](pagination.md) for details.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,41 @@
+# Event Types
+
+The `events` commands accept an `--event-type` flag to filter by event type.
+
+## Valid event types
+
+| Type | Description |
+|---|---|
+| `sale` | NFT sold |
+| `transfer` | NFT transferred between wallets |
+| `mint` | NFT minted |
+| `listing` | NFT listed for sale |
+| `offer` | Offer made on an NFT |
+| `trait_offer` | Offer made on NFTs with a specific trait |
+| `collection_offer` | Offer made on any NFT in a collection |
+
+## CLI usage
+
+```bash
+# Filter by event type
+opensea events list --event-type sale --limit 5
+
+# Combine with other filters
+opensea events by-collection mfers --event-type transfer --limit 10
+opensea events by-account 0x123... --event-type mint --chain ethereum
+opensea events by-nft ethereum 0x123... 1 --event-type listing
+
+# Time-based filtering (events list only)
+opensea events list --event-type sale --after 1700000000 --before 1700100000
+```
+
+## SDK usage
+
+```typescript
+const { asset_events } = await client.events.byCollection("mfers", {
+  eventType: "sale",
+  limit: 10,
+})
+```
+
+Note: The CLI uses `--event-type` (kebab-case) while the SDK uses `eventType` (camelCase).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,145 @@
+# Examples
+
+Real-world examples using the [tiny dinos](https://opensea.io/collection/tiny-dinos-eth) and [mfers](https://opensea.io/collection/mfers) collections.
+
+## Collections
+
+```bash
+# Get collection details
+opensea collections get tiny-dinos-eth
+
+# List collections with a limit
+opensea collections list --limit 2
+
+# Get collection stats (volume, floor price, etc.)
+opensea collections stats tiny-dinos-eth
+
+# Get collection traits
+opensea collections traits tiny-dinos-eth
+```
+
+## NFTs
+
+```bash
+# Get a specific NFT by chain/contract/token-id
+opensea nfts get ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1
+
+# List NFTs in a collection
+opensea nfts list-by-collection tiny-dinos-eth --limit 2
+
+# List NFTs by contract address
+opensea nfts list-by-contract ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 --limit 2
+
+# List NFTs owned by an account
+opensea nfts list-by-account ethereum 0x21130e908bba2d41b63fbca7caa131285b8724f8 --limit 2
+
+# Get contract details
+opensea nfts contract ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4
+
+# Refresh NFT metadata
+opensea nfts refresh ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1
+```
+
+## Listings
+
+```bash
+# Get all listings for a collection
+opensea listings all tiny-dinos-eth --limit 2
+
+# Get best (cheapest) listings
+opensea listings best tiny-dinos-eth --limit 2
+
+# Get the best listing for a specific NFT
+opensea listings best-for-nft mfers 3490
+```
+
+## Offers
+
+```bash
+# Get all offers for a collection
+opensea offers all tiny-dinos-eth --limit 2
+
+# Get collection offers
+opensea offers collection tiny-dinos-eth --limit 2
+
+# Get best offer for a specific NFT
+opensea offers best-for-nft tiny-dinos-eth 1
+
+# Get trait offers (type and value are required)
+opensea offers traits tiny-dinos-eth --type background --value blue --limit 2
+```
+
+## Events
+
+```bash
+# List recent events across all collections
+opensea events list --limit 2
+
+# Get events for a collection
+opensea events by-collection tiny-dinos-eth --limit 2
+
+# Get events for a specific NFT
+opensea events by-nft ethereum 0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4 1 --limit 2
+
+# Get events for an account
+opensea events by-account 0x21130e908bba2d41b63fbca7caa131285b8724f8 --limit 2
+```
+
+## Search
+
+```bash
+# Search for collections
+opensea search collections mfers
+
+# Search for NFTs
+opensea search nfts "cool cat" --limit 5
+
+# Search for NFTs within a specific collection
+opensea search nfts "rare" --collection tiny-dinos-eth --limit 5
+
+# Search for tokens/currencies
+opensea search tokens eth --limit 5
+
+# Search for tokens on a specific chain
+opensea search tokens usdc --chain base --limit 5
+
+# Search for accounts
+opensea search accounts vitalik --limit 5
+```
+
+## Tokens
+
+```bash
+# Get trending tokens
+opensea tokens trending --limit 2
+
+# Get trending tokens on a specific chain
+opensea tokens trending --chains base --limit 2
+
+# Get top tokens by 24-hour volume
+opensea tokens top --limit 2
+
+# Get top tokens on a specific chain
+opensea tokens top --chains base --limit 2
+
+# Get details for a specific token (DebtReliefBot on Base)
+opensea tokens get base 0x3ec2156d4c0a9cbdab4a016633b7bcf6a8d68ea2
+```
+
+## Swaps
+
+```bash
+# Get a swap quote for USDC to DRB on Base
+opensea swaps quote \
+  --from-chain base --from-address 0x833589fcd6edb6e08f4c7c32d4f71b54bda02913 \
+  --to-chain base --to-address 0x3ec2156d4c0a9cbdab4a016633b7bcf6a8d68ea2 \
+  --quantity 1000000 \
+  --address 0x21130e908bba2d41b63fbca7caa131285b8724f8
+```
+
+## Accounts
+
+```bash
+# Get account details
+opensea accounts get 0x21130e908bba2d41b63fbca7caa131285b8724f8
+```

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,0 +1,72 @@
+# Pagination
+
+The OpenSea API uses cursor-based pagination. Paginated responses include a `next` field containing an opaque cursor string. Pass this cursor back to fetch the next page.
+
+## CLI
+
+Most list commands support `--next <cursor>` (or `--cursor <cursor>` for tokens):
+
+```bash
+# First page
+opensea collections list --limit 5
+
+# The response includes a "next" cursor — pass it to get the next page
+opensea collections list --limit 5 --next "LXBrPTEwMDA..."
+
+# Tokens use --cursor instead of --next
+opensea tokens trending --limit 5
+opensea tokens trending --limit 5 --cursor "abc123..."
+```
+
+### Commands that support pagination
+
+| Command | Cursor flag |
+|---|---|
+| `collections list` | `--next` |
+| `nfts list-by-collection` | `--next` |
+| `nfts list-by-contract` | `--next` |
+| `nfts list-by-account` | `--next` |
+| `listings all` | `--next` |
+| `listings best` | `--next` |
+| `offers all` | `--next` |
+| `offers collection` | `--next` |
+| `offers traits` | `--next` |
+| `events list` | `--next` |
+| `events by-account` | `--next` |
+| `events by-collection` | `--next` |
+| `events by-nft` | `--next` |
+| `tokens trending` | `--cursor` |
+| `tokens top` | `--cursor` |
+
+## SDK
+
+SDK methods return a `next` cursor in the response object:
+
+```typescript
+const client = new OpenSeaCLI({ apiKey: process.env.OPENSEA_API_KEY })
+
+// First page
+const page1 = await client.collections.list({ limit: 5 })
+console.log(page1.collections)
+
+// Next page
+if (page1.next) {
+  const page2 = await client.collections.list({ limit: 5, next: page1.next })
+}
+```
+
+### Iterating through all pages
+
+```typescript
+let cursor: string | undefined
+do {
+  const result = await client.nfts.listByCollection("mfers", {
+    limit: 50,
+    next: cursor,
+  })
+  for (const nft of result.nfts) {
+    // process each NFT
+  }
+  cursor = result.next
+} while (cursor)
+```

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,211 @@
+# SDK Reference
+
+The `@opensea/cli` package exports a programmatic SDK for use in TypeScript/JavaScript applications.
+
+## Setup
+
+```typescript
+import { OpenSeaCLI } from "@opensea/cli"
+
+const client = new OpenSeaCLI({ apiKey: process.env.OPENSEA_API_KEY })
+```
+
+### Configuration
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `apiKey` | `string` | *required* | OpenSea API key |
+| `baseUrl` | `string` | `https://api.opensea.io` | API base URL override |
+| `graphqlUrl` | `string` | `https://gql.opensea.io/graphql` | GraphQL URL override |
+| `chain` | `string` | `"ethereum"` | Default chain |
+
+## Collections
+
+```typescript
+const collection = await client.collections.get("mfers")
+
+const { collections, next } = await client.collections.list({
+  chain: "ethereum",
+  limit: 10,
+  orderBy: "seven_day_volume",
+  creatorUsername: "some-user",
+  includeHidden: false,
+  next: "cursor_string",
+})
+
+const stats = await client.collections.stats("mfers")
+
+const traits = await client.collections.traits("mfers")
+```
+
+## NFTs
+
+```typescript
+const { nft } = await client.nfts.get("ethereum", "0x123...", "1")
+
+const { nfts, next } = await client.nfts.listByCollection("mfers", {
+  limit: 10,
+  next: "cursor_string",
+})
+
+const { nfts, next } = await client.nfts.listByContract("ethereum", "0x123...", {
+  limit: 10,
+})
+
+const { nfts, next } = await client.nfts.listByAccount("ethereum", "0x123...", {
+  limit: 10,
+})
+
+await client.nfts.refresh("ethereum", "0x123...", "1")
+
+const contract = await client.nfts.getContract("ethereum", "0x123...")
+```
+
+## Listings
+
+```typescript
+const { listings, next } = await client.listings.all("mfers", { limit: 10 })
+
+const { listings, next } = await client.listings.best("mfers", { limit: 10 })
+
+const listing = await client.listings.bestForNFT("mfers", "3490")
+```
+
+## Offers
+
+```typescript
+const { offers, next } = await client.offers.all("mfers", { limit: 10 })
+
+const { offers, next } = await client.offers.collection("mfers", { limit: 10 })
+
+const offer = await client.offers.bestForNFT("mfers", "1")
+
+const { offers, next } = await client.offers.traits("mfers", {
+  type: "background",
+  value: "blue",
+  limit: 10,
+})
+```
+
+## Events
+
+```typescript
+const { asset_events, next } = await client.events.list({
+  eventType: "sale",
+  chain: "ethereum",
+  after: 1700000000,
+  before: 1700100000,
+  limit: 10,
+})
+
+const { asset_events, next } = await client.events.byAccount("0x123...", {
+  eventType: "transfer",
+  chain: "ethereum",
+  limit: 10,
+})
+
+const { asset_events, next } = await client.events.byCollection("mfers", {
+  eventType: "sale",
+  limit: 10,
+})
+
+const { asset_events, next } = await client.events.byNFT(
+  "ethereum",
+  "0x123...",
+  "1",
+  { eventType: "sale", limit: 10 },
+)
+```
+
+## Accounts
+
+```typescript
+const account = await client.accounts.get("0x123...")
+```
+
+## Tokens
+
+```typescript
+const { tokens, next } = await client.tokens.trending({
+  chains: ["base", "ethereum"],
+  limit: 10,
+  cursor: "cursor_string",
+})
+
+const { tokens, next } = await client.tokens.top({
+  chains: ["base"],
+  limit: 10,
+})
+
+const tokenDetails = await client.tokens.get("base", "0x123...")
+```
+
+## Search
+
+Search methods use GraphQL and return different result shapes than the REST API.
+
+```typescript
+const collections = await client.search.collections("mfers", {
+  chains: ["ethereum"],
+  limit: 5,
+})
+
+const nfts = await client.search.nfts("cool cat", {
+  collection: "cool-cats-nft",
+  chains: ["ethereum"],
+  limit: 5,
+})
+
+const tokens = await client.search.tokens("usdc", {
+  chain: "base",
+  limit: 5,
+})
+
+const accounts = await client.search.accounts("vitalik", { limit: 5 })
+```
+
+## Swaps
+
+```typescript
+const { quote, transactions } = await client.swaps.quote({
+  fromChain: "base",
+  fromAddress: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  toChain: "base",
+  toAddress: "0x3ec2156d4c0a9cbdab4a016633b7bcf6a8d68ea2",
+  quantity: "1000000",
+  address: "0x21130e908bba2d41b63fbca7caa131285b8724f8",
+  slippage: 0.01,
+  recipient: "0x...",
+})
+```
+
+## Error Handling
+
+All API errors throw `OpenSeaAPIError` with structured fields:
+
+```typescript
+import { OpenSeaCLI, OpenSeaAPIError } from "@opensea/cli"
+
+const client = new OpenSeaCLI({ apiKey: process.env.OPENSEA_API_KEY })
+
+try {
+  const collection = await client.collections.get("nonexistent")
+} catch (error) {
+  if (error instanceof OpenSeaAPIError) {
+    console.error(error.statusCode)    // e.g. 404
+    console.error(error.responseBody)  // raw response body
+    console.error(error.path)          // e.g. "/api/v2/collections/nonexistent"
+  }
+}
+```
+
+## Exports
+
+The package exports:
+
+| Export | Description |
+|---|---|
+| `OpenSeaCLI` | Main SDK class with all API domain methods |
+| `OpenSeaClient` | Low-level HTTP client (for advanced usage) |
+| `OpenSeaAPIError` | Error class thrown on API failures |
+| All types from `types/api.ts` | TypeScript interfaces for all API responses |


### PR DESCRIPTION
# docs: restructure README into concise overview with docs/ reference pages

## Summary

Slims down the README from ~340 lines to ~180 lines by moving detailed content into a new `docs/` folder. The README now serves as a quick-start guide with a command summary table, linking out to dedicated reference pages for deeper information.

**README changes:**
- Replaced the full inline CLI command reference with a compact command summary table
- Replaced the full inline examples section with a Quick Start showing the most common commands
- Trimmed the SDK section to a focused quickstart (was showing all 9 domains inline, now shows the most useful ones)
- Added `OpenSeaAPIError` error handling example
- Added a Development section with build/test/lint commands
- Added a Docs section linking to all reference pages

**New `docs/` pages:**
- `docs/cli-reference.md` — full command reference with all options and flags (moved from README)
- `docs/examples.md` — real-world usage examples for every command (moved from README)
- `docs/sdk.md` — full SDK API reference with all methods, config options, error handling, and exports
- `docs/pagination.md` — pagination patterns for CLI and SDK, including a table of all paginated commands and an iteration example
- `docs/events.md` — event type reference table with CLI and SDK usage

No code changes — docs only.

## Updates since last revision

The initial commit added detailed content directly into the README, making it quite long. Per reviewer feedback, a second commit restructured the approach:
- Moved the full CLI reference to `docs/cli-reference.md`
- Moved all examples to `docs/examples.md`
- Slimmed the README to a scannable overview with links into `docs/`

## Review & Testing Checklist for Human

- [ ] Verify all internal links resolve correctly on GitHub (README links to `docs/cli-reference.md`, `docs/examples.md`, `docs/sdk.md`, `docs/pagination.md`, `docs/events.md`; and cross-links within docs/ like `docs/cli-reference.md` linking to `events.md` and `pagination.md`)
- [ ] Spot-check that CLI options in `docs/cli-reference.md` match actual behavior — especially `--creator`, `--include-hidden`, `--after`, `--before` flags which were sourced from command source files but not previously documented
- [ ] Skim `docs/sdk.md` examples against `src/sdk.ts` class signatures for accuracy (note: the SDK examples use repeated destructuring like `const { nfts, next }` in multiple places which is fine as documentation but would need unique names in real code)

### Notes

- All documented options were verified against source files in `src/commands/*.ts` and `src/sdk.ts`
- `docs/pagination.md` notes that `tokens` commands use `--cursor` while all others use `--next` — this is an existing inconsistency in the codebase, not introduced by this PR
- Confidence: **high** — docs-only changes with no functional risk, content sourced directly from source code
- Link to Devin run: https://app.devin.ai/sessions/8bb30b3c11be40f792be6a9f8ac058a8
- Requested by: @ryanio