### PR TITLE
Make pagination consistent (use next cursor everywhere)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -73,8 +73,8 @@ opensea search accounts <query> [--limit <n>]
 ## Tokens
 
 ```bash
-opensea tokens trending [--chains <chains>] [--limit <n>] [--cursor <cursor>]
-opensea tokens top [--chains <chains>] [--limit <n>] [--cursor <cursor>]
+opensea tokens trending [--chains <chains>] [--limit <n>] [--next <cursor>]
+opensea tokens top [--chains <chains>] [--limit <n>] [--next <cursor>]
 opensea tokens get <chain> <address>
 ```
 
@@ -90,4 +90,4 @@ opensea swaps quote --from-chain <chain> --from-address <address> --to-chain <ch
 opensea accounts get <address>
 ```
 
-> All list commands support cursor-based pagination. See [pagination.md](pagination.md) for details.
+> REST list commands support cursor-based pagination. Search commands return a flat list with no cursor. See [pagination.md](pagination.md) for details.

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -4,7 +4,7 @@ The OpenSea API uses cursor-based pagination. Paginated responses include a `nex
 
 ## CLI
 
-Most list commands support `--next <cursor>` (or `--cursor <cursor>` for tokens):
+All paginated commands use `--next <cursor>`:
 
 ```bash
 # First page
@@ -13,9 +13,9 @@ opensea collections list --limit 5
 # The response includes a "next" cursor — pass it to get the next page
 opensea collections list --limit 5 --next "LXBrPTEwMDA..."
 
-# Tokens use --cursor instead of --next
+# Tokens also use --next
 opensea tokens trending --limit 5
-opensea tokens trending --limit 5 --cursor "abc123..."
+opensea tokens trending --limit 5 --next "abc123..."
 ```
 
 ### Commands that support pagination
@@ -23,6 +23,7 @@ opensea tokens trending --limit 5 --cursor "abc123..."
 | Command | Cursor flag |
 |---|---|
 | `collections list` | `--next` |
+
 | `nfts list-by-collection` | `--next` |
 | `nfts list-by-contract` | `--next` |
 | `nfts list-by-account` | `--next` |
@@ -35,8 +36,10 @@ opensea tokens trending --limit 5 --cursor "abc123..."
 | `events by-account` | `--next` |
 | `events by-collection` | `--next` |
 | `events by-nft` | `--next` |
-| `tokens trending` | `--cursor` |
-| `tokens top` | `--cursor` |
+| `tokens trending` | `--next` |
+| `tokens top` | `--next` |
+
+> **Note:** Search commands (`search collections`, `search nfts`, `search tokens`, `search accounts`) do not support cursor-based pagination. The underlying GraphQL API returns a flat list with no `next` cursor.
 
 ## SDK
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -129,7 +129,7 @@ const account = await client.accounts.get("0x123...")
 const { tokens, next } = await client.tokens.trending({
   chains: ["base", "ethereum"],
   limit: 10,
-  cursor: "cursor_string",
+  next: "cursor_string",
 })
 
 const { tokens, next } = await client.tokens.top({
@@ -142,7 +142,7 @@ const tokenDetails = await client.tokens.get("base", "0x123...")
 
 ## Search
 
-Search methods use GraphQL and return different result shapes than the REST API.
+Search methods use GraphQL and return different result shapes than the REST API. Search endpoints do not currently expose a `next` cursor for pagination; use `limit` to control result count.
 
 ```typescript
 const collections = await client.search.collections("mfers", {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensea/cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensea/cli",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "description": "OpenSea CLI - Query the OpenSea API from the command line or programmatically",
   "main": "dist/index.js",

--- a/src/commands/tokens.ts
+++ b/src/commands/tokens.ts
@@ -16,16 +16,16 @@ export function tokensCommand(
     .description("Get trending tokens based on OpenSea's trending score")
     .option("--chains <chains>", "Comma-separated list of chains to filter by")
     .option("--limit <limit>", "Number of results (max 100)", "20")
-    .option("--cursor <cursor>", "Pagination cursor")
+    .option("--next <cursor>", "Pagination cursor")
     .action(
-      async (options: { chains?: string; limit: string; cursor?: string }) => {
+      async (options: { chains?: string; limit: string; next?: string }) => {
         const client = getClient()
         const result = await client.get<{ tokens: Token[]; next?: string }>(
           "/api/v2/tokens/trending",
           {
             chains: options.chains,
             limit: Number.parseInt(options.limit, 10),
-            cursor: options.cursor,
+            cursor: options.next,
           },
         )
         console.log(formatOutput(result, getFormat()))
@@ -37,16 +37,16 @@ export function tokensCommand(
     .description("Get top tokens ranked by 24-hour trading volume")
     .option("--chains <chains>", "Comma-separated list of chains to filter by")
     .option("--limit <limit>", "Number of results (max 100)", "20")
-    .option("--cursor <cursor>", "Pagination cursor")
+    .option("--next <cursor>", "Pagination cursor")
     .action(
-      async (options: { chains?: string; limit: string; cursor?: string }) => {
+      async (options: { chains?: string; limit: string; next?: string }) => {
         const client = getClient()
         const result = await client.get<{ tokens: Token[]; next?: string }>(
           "/api/v2/tokens/top",
           {
             chains: options.chains,
             limit: Number.parseInt(options.limit, 10),
-            cursor: options.cursor,
+            cursor: options.next,
           },
         )
         console.log(formatOutput(result, getFormat()))

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -317,24 +317,24 @@ class TokensAPI {
   async trending(options?: {
     limit?: number
     chains?: string[]
-    cursor?: string
+    next?: string
   }): Promise<{ tokens: Token[]; next?: string }> {
     return this.client.get("/api/v2/tokens/trending", {
       limit: options?.limit,
       chains: options?.chains?.join(","),
-      cursor: options?.cursor,
+      cursor: options?.next,
     })
   }
 
   async top(options?: {
     limit?: number
     chains?: string[]
-    cursor?: string
+    next?: string
   }): Promise<{ tokens: Token[]; next?: string }> {
     return this.client.get("/api/v2/tokens/top", {
       limit: options?.limit,
       chains: options?.chains?.join(","),
-      cursor: options?.cursor,
+      cursor: options?.next,
     })
   }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -250,11 +250,6 @@ export interface GetTraitsResponse {
   counts: { [traitType: string]: TraitCounts }
 }
 
-export interface PaginatedResponse<T> {
-  next?: string
-  results: T[]
-}
-
 export interface Token {
   address: string
   chain: string

--- a/test/commands/tokens.test.ts
+++ b/test/commands/tokens.test.ts
@@ -27,7 +27,15 @@ describe("tokensCommand", () => {
 
     const cmd = tokensCommand(ctx.getClient, ctx.getFormat)
     await cmd.parseAsync(
-      ["trending", "--chains", "ethereum,base", "--limit", "10"],
+      [
+        "trending",
+        "--chains",
+        "ethereum,base",
+        "--limit",
+        "10",
+        "--next",
+        "abc123",
+      ],
       { from: "user" },
     )
 
@@ -36,6 +44,7 @@ describe("tokensCommand", () => {
       expect.objectContaining({
         chains: "ethereum,base",
         limit: 10,
+        cursor: "abc123",
       }),
     )
   })
@@ -44,11 +53,13 @@ describe("tokensCommand", () => {
     ctx.mockClient.get.mockResolvedValue({ tokens: [] })
 
     const cmd = tokensCommand(ctx.getClient, ctx.getFormat)
-    await cmd.parseAsync(["top", "--limit", "5"], { from: "user" })
+    await cmd.parseAsync(["top", "--limit", "5", "--next", "cursor1"], {
+      from: "user",
+    })
 
     expect(ctx.mockClient.get).toHaveBeenCalledWith(
       "/api/v2/tokens/top",
-      expect.objectContaining({ limit: 5 }),
+      expect.objectContaining({ limit: 5, cursor: "cursor1" }),
     )
   })
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -294,6 +294,16 @@ describe("OpenSeaCLI", () => {
       })
     })
 
+    it("trending maps next option to cursor param", async () => {
+      mockGet.mockResolvedValue({ tokens: [] })
+      await sdk.tokens.trending({ next: "cursor1" })
+      expect(mockGet).toHaveBeenCalledWith("/api/v2/tokens/trending", {
+        limit: undefined,
+        chains: undefined,
+        cursor: "cursor1",
+      })
+    })
+
     it("trending with no options", async () => {
       mockGet.mockResolvedValue({ tokens: [] })
       await sdk.tokens.trending()
@@ -301,6 +311,16 @@ describe("OpenSeaCLI", () => {
         limit: undefined,
         chains: undefined,
         cursor: undefined,
+      })
+    })
+
+    it("top maps next option to cursor param", async () => {
+      mockGet.mockResolvedValue({ tokens: [] })
+      await sdk.tokens.top({ limit: 5, next: "cursor2" })
+      expect(mockGet).toHaveBeenCalledWith("/api/v2/tokens/top", {
+        limit: 5,
+        chains: undefined,
+        cursor: "cursor2",
       })
     })
 


### PR DESCRIPTION
# Standardize pagination to use `next` cursors across CLI + SDK

## Summary
- **CLI:** Updated `tokens trending` and `tokens top` to use `--next <cursor>` instead of `--cursor <cursor>` (to match all other paginated commands). Internally still sends the server query param as `cursor`.
- **SDK:** Updated `TokensAPI.trending()` / `TokensAPI.top()` options to accept `{ next?: string }` (instead of `{ cursor?: string }`) and map `next → cursor` in the request params.
- **Types:** Removed unused `PaginatedResponse<T>` type since SDK response shapes vary by endpoint key (`nfts`, `listings`, `offers`, etc.).
- **Docs:** Updated CLI/SDK pagination docs to reflect `--next` everywhere and documented that **search commands don’t expose cursor-based pagination**.
- **Version:** Bumped `@opensea/cli` minor version `0.2.1 → 0.3.0`.
- **Tests:** Updated/added tests covering the new CLI flag and SDK `next → cursor` mapping.

## Review & Testing Checklist for Human
- [ ] Confirm **tokens CLI** pagination works as intended: `opensea tokens trending --limit 5 --next "<cursor>"` fetches the next page (and that the outgoing query param is still `cursor`).
- [ ] Confirm **SDK** pagination works: `client.tokens.trending({ next: "<cursor>" })` / `top({ next: "<cursor>" })` correctly advances pages.
- [ ] Sanity-check docs for any remaining references to `--cursor` / `cursor` as the public pagination option (especially around tokens + pagination docs).

### Notes
- This is a **breaking interface change** (CLI flag + SDK option rename), hence the minor version bump.
- Link to Devin run: https://app.devin.ai/sessions/323873ce874140f58eefd24613c6e874
- Requested by: @ryanio
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
