### PR TITLE
feat: add error handling, validation, timeout, and verbose mode

### DIFF
--- a/src/commands/collections.ts
+++ b/src/commands/collections.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander"
 import type { OpenSeaClient } from "../client.js"
 import { formatOutput } from "../output.js"
+import { parseIntOption } from "../parse.js"
 import type {
   Chain,
   Collection,
@@ -57,7 +58,7 @@ export function collectionsCommand(
           order_by: options.orderBy as CollectionOrderBy | undefined,
           creator_username: options.creator,
           include_hidden: options.includeHidden,
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         })
         console.log(formatOutput(result, getFormat()))

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander"
 import type { OpenSeaClient } from "../client.js"
 import { formatOutput } from "../output.js"
+import { parseIntOption } from "../parse.js"
 import type { AssetEvent } from "../types/index.js"
 
 export function eventsCommand(
@@ -36,12 +37,14 @@ export function eventsCommand(
           next?: string
         }>("/api/v2/events", {
           event_type: options.eventType,
-          after: options.after ? Number.parseInt(options.after, 10) : undefined,
+          after: options.after
+            ? parseIntOption(options.after, "--after")
+            : undefined,
           before: options.before
-            ? Number.parseInt(options.before, 10)
+            ? parseIntOption(options.before, "--before")
             : undefined,
           chain: options.chain,
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         })
         console.log(formatOutput(result, getFormat()))
@@ -73,7 +76,7 @@ export function eventsCommand(
         }>(`/api/v2/events/accounts/${address}`, {
           event_type: options.eventType,
           chain: options.chain,
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         })
         console.log(formatOutput(result, getFormat()))
@@ -102,7 +105,7 @@ export function eventsCommand(
           next?: string
         }>(`/api/v2/events/collection/${slug}`, {
           event_type: options.eventType,
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         })
         console.log(formatOutput(result, getFormat()))
@@ -137,7 +140,7 @@ export function eventsCommand(
           `/api/v2/events/chain/${chain}/contract/${contract}/nfts/${tokenId}`,
           {
             event_type: options.eventType,
-            limit: Number.parseInt(options.limit, 10),
+            limit: parseIntOption(options.limit, "--limit"),
             next: options.next,
           },
         )

--- a/src/commands/listings.ts
+++ b/src/commands/listings.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander"
 import type { OpenSeaClient } from "../client.js"
 import { formatOutput } from "../output.js"
+import { parseIntOption } from "../parse.js"
 import type { Listing } from "../types/index.js"
 
 export function listingsCommand(
@@ -22,7 +23,7 @@ export function listingsCommand(
           listings: Listing[]
           next?: string
         }>(`/api/v2/listings/collection/${collection}/all`, {
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         })
         console.log(formatOutput(result, getFormat()))
@@ -42,7 +43,7 @@ export function listingsCommand(
           listings: Listing[]
           next?: string
         }>(`/api/v2/listings/collection/${collection}/best`, {
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         })
         console.log(formatOutput(result, getFormat()))

--- a/src/commands/nfts.ts
+++ b/src/commands/nfts.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander"
 import type { OpenSeaClient } from "../client.js"
 import { formatOutput } from "../output.js"
+import { parseIntOption } from "../parse.js"
 import type { Contract, NFT } from "../types/index.js"
 
 export function nftsCommand(
@@ -34,7 +35,7 @@ export function nftsCommand(
       const result = await client.get<{ nfts: NFT[]; next?: string }>(
         `/api/v2/collection/${slug}/nfts`,
         {
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         },
       )
@@ -58,7 +59,7 @@ export function nftsCommand(
         const result = await client.get<{ nfts: NFT[]; next?: string }>(
           `/api/v2/chain/${chain}/contract/${contract}/nfts`,
           {
-            limit: Number.parseInt(options.limit, 10),
+            limit: parseIntOption(options.limit, "--limit"),
             next: options.next,
           },
         )
@@ -83,7 +84,7 @@ export function nftsCommand(
         const result = await client.get<{ nfts: NFT[]; next?: string }>(
           `/api/v2/chain/${chain}/account/${address}/nfts`,
           {
-            limit: Number.parseInt(options.limit, 10),
+            limit: parseIntOption(options.limit, "--limit"),
             next: options.next,
           },
         )

--- a/src/commands/offers.ts
+++ b/src/commands/offers.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander"
 import type { OpenSeaClient } from "../client.js"
 import { formatOutput } from "../output.js"
+import { parseIntOption } from "../parse.js"
 import type { Offer } from "../types/index.js"
 
 export function offersCommand(
@@ -22,7 +23,7 @@ export function offersCommand(
           offers: Offer[]
           next?: string
         }>(`/api/v2/offers/collection/${collection}/all`, {
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         })
         console.log(formatOutput(result, getFormat()))
@@ -42,7 +43,7 @@ export function offersCommand(
           offers: Offer[]
           next?: string
         }>(`/api/v2/offers/collection/${collection}`, {
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         })
         console.log(formatOutput(result, getFormat()))
@@ -87,7 +88,7 @@ export function offersCommand(
         }>(`/api/v2/offers/collection/${collection}/traits`, {
           type: options.type,
           value: options.value,
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           next: options.next,
         })
         console.log(formatOutput(result, getFormat()))

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander"
 import type { OpenSeaClient } from "../client.js"
 import { formatOutput } from "../output.js"
+import { parseIntOption } from "../parse.js"
 import {
   SEARCH_ACCOUNTS_QUERY,
   SEARCH_COLLECTIONS_QUERY,
@@ -35,7 +36,7 @@ export function searchCommand(
           collectionsByQuery: SearchCollectionResult[]
         }>(SEARCH_COLLECTIONS_QUERY, {
           query,
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           chains: options.chains?.split(","),
         })
         console.log(formatOutput(result.collectionsByQuery, getFormat()))
@@ -60,7 +61,7 @@ export function searchCommand(
         }>(SEARCH_NFTS_QUERY, {
           query,
           collectionSlug: options.collection,
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           chains: options.chains?.split(","),
         })
         console.log(formatOutput(result.itemsByQuery, getFormat()))
@@ -80,7 +81,7 @@ export function searchCommand(
           currenciesByQuery: SearchTokenResult[]
         }>(SEARCH_TOKENS_QUERY, {
           query,
-          limit: Number.parseInt(options.limit, 10),
+          limit: parseIntOption(options.limit, "--limit"),
           chain: options.chain,
         })
         console.log(formatOutput(result.currenciesByQuery, getFormat()))
@@ -98,7 +99,7 @@ export function searchCommand(
         accountsByQuery: SearchAccountResult[]
       }>(SEARCH_ACCOUNTS_QUERY, {
         query,
-        limit: Number.parseInt(options.limit, 10),
+        limit: parseIntOption(options.limit, "--limit"),
       })
       console.log(formatOutput(result.accountsByQuery, getFormat()))
     })

--- a/src/commands/swaps.ts
+++ b/src/commands/swaps.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander"
 import type { OpenSeaClient } from "../client.js"
 import { formatOutput } from "../output.js"
+import { parseFloatOption } from "../parse.js"
 import type { SwapQuoteResponse } from "../types/index.js"
 
 export function swapsCommand(
@@ -58,7 +59,7 @@ export function swapsCommand(
             quantity: options.quantity,
             address: options.address,
             slippage: options.slippage
-              ? Number.parseFloat(options.slippage)
+              ? parseFloatOption(options.slippage, "--slippage")
               : undefined,
             recipient: options.recipient,
           },

--- a/src/commands/tokens.ts
+++ b/src/commands/tokens.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander"
 import type { OpenSeaClient } from "../client.js"
 import { formatOutput } from "../output.js"
+import { parseIntOption } from "../parse.js"
 import type { Chain, Token, TokenDetails } from "../types/index.js"
 
 export function tokensCommand(
@@ -24,7 +25,8 @@ export function tokensCommand(
           "/api/v2/tokens/trending",
           {
             chains: options.chains,
-            limit: Number.parseInt(options.limit, 10),
+            limit: parseIntOption(options.limit, "--limit"),
+            // Tokens API uses "cursor" instead of "next" as the query param
             cursor: options.next,
           },
         )
@@ -45,7 +47,8 @@ export function tokensCommand(
           "/api/v2/tokens/top",
           {
             chains: options.chains,
-            limit: Number.parseInt(options.limit, 10),
+            limit: parseIntOption(options.limit, "--limit"),
+            // Tokens API uses "cursor" instead of "next" as the query param
             cursor: options.next,
           },
         )

--- a/src/output.ts
+++ b/src/output.ts
@@ -35,6 +35,7 @@ function formatTable(data: unknown): string {
 
   if (data && typeof data === "object") {
     const entries = Object.entries(data as Record<string, unknown>)
+    if (entries.length === 0) return "(empty)"
     const maxKeyLength = Math.max(...entries.map(([k]) => k.length))
     return entries
       .map(([key, value]) => {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,0 +1,15 @@
+export function parseIntOption(value: string, name: string): number {
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Invalid value for ${name}: "${value}" is not an integer`)
+  }
+  return parsed
+}
+
+export function parseFloatOption(value: string, name: string): number {
+  const parsed = Number.parseFloat(value)
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Invalid value for ${name}: "${value}" is not a number`)
+  }
+  return parsed
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -319,6 +319,8 @@ class TokensAPI {
     chains?: string[]
     next?: string
   }): Promise<{ tokens: Token[]; next?: string }> {
+    // The tokens API uses "cursor" as its query param instead of "next".
+    // The SDK accepts "next" for consistency with all other endpoints.
     return this.client.get("/api/v2/tokens/trending", {
       limit: options?.limit,
       chains: options?.chains?.join(","),
@@ -331,6 +333,8 @@ class TokensAPI {
     chains?: string[]
     next?: string
   }): Promise<{ tokens: Token[]; next?: string }> {
+    // The tokens API uses "cursor" as its query param instead of "next".
+    // The SDK accepts "next" for consistency with all other endpoints.
     return this.client.get("/api/v2/tokens/top", {
       limit: options?.limit,
       chains: options?.chains?.join(","),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,8 @@ export interface OpenSeaClientConfig {
   baseUrl?: string
   graphqlUrl?: string
   chain?: string
+  timeout?: number
+  verbose?: boolean
 }
 
 export interface CommandOptions {

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -34,6 +34,10 @@ describe("formatOutput", () => {
       expect(formatOutput([], "table")).toBe("(empty)")
     })
 
+    it("returns (empty) for empty object", () => {
+      expect(formatOutput({}, "table")).toBe("(empty)")
+    })
+
     it("formats an object as key-value pairs", () => {
       const data = { name: "test", count: 5 }
       const result = formatOutput(data, "table")

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { parseFloatOption, parseIntOption } from "../src/parse.js"
+
+describe("parseIntOption", () => {
+  it("parses valid integers", () => {
+    expect(parseIntOption("42", "--limit")).toBe(42)
+    expect(parseIntOption("0", "--limit")).toBe(0)
+    expect(parseIntOption("-1", "--offset")).toBe(-1)
+  })
+
+  it("throws on non-numeric strings", () => {
+    expect(() => parseIntOption("abc", "--limit")).toThrow(
+      'Invalid value for --limit: "abc" is not an integer',
+    )
+  })
+
+  it("throws on empty string", () => {
+    expect(() => parseIntOption("", "--limit")).toThrow(
+      'Invalid value for --limit: "" is not an integer',
+    )
+  })
+})
+
+describe("parseFloatOption", () => {
+  it("parses valid floats", () => {
+    expect(parseFloatOption("0.5", "--slippage")).toBe(0.5)
+    expect(parseFloatOption("1", "--slippage")).toBe(1)
+    expect(parseFloatOption("0.01", "--slippage")).toBe(0.01)
+  })
+
+  it("throws on non-numeric strings", () => {
+    expect(() => parseFloatOption("abc", "--slippage")).toThrow(
+      'Invalid value for --slippage: "abc" is not a number',
+    )
+  })
+
+  it("throws on empty string", () => {
+    expect(() => parseFloatOption("", "--slippage")).toThrow(
+      'Invalid value for --slippage: "" is not a number',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- **Network error handling**: CLI now catches `TypeError` (DNS/timeout/connection failures) and other non-API errors, outputting structured JSON to stderr instead of raw stack traces
- **NaN validation**: New `parseIntOption`/`parseFloatOption` helpers replace all 21 raw `Number.parseInt`/`Number.parseFloat` calls across 8 command files — passing `--limit abc` now shows a clear error instead of silently sending NaN to the API
- **Empty object fix**: `formatTable({})` returns `"(empty)"` instead of crashing on `Math.max(...[])`
- **Fetch timeout**: All fetch calls use `AbortSignal.timeout()` (default 30s), configurable via `--timeout <ms>` CLI option or `timeout` in SDK config
- **Verbose mode**: `--verbose` flag logs `[verbose] GET <url>` and `[verbose] 200 OK` to stderr for debugging
- **Extended `post()` signature**: Now accepts optional `body` and `params` arguments for SDK consumers
- **Cursor/next documentation**: Inline comments explaining why tokens API uses `cursor` instead of `next`

## Test plan

- [x] `npm run test` — 130 tests pass (was 115, +15 new)
- [x] `npm run lint` — Biome passes
- [x] `npm run type-check` — no TypeScript errors
- [ ] Manual: `opensea collections get boredapeyachtclub` works
- [ ] Manual: `opensea collections get boredapeyachtclub --verbose` shows request/response on stderr
- [ ] Manual: `opensea tokens trending --limit abc` shows clear error instead of silent NaN
- [ ] Manual: unplug network → `opensea collections list` shows structured JSON error, not stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
