### PR TITLE
fix: pagination docs table formatting

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -20,23 +20,21 @@ opensea tokens trending --limit 5 --next "abc123..."
 
 ### Commands that support pagination
 
-| Command | Cursor flag |
-|---|---|
-| `collections list` | `--next` |
-| `nfts list-by-collection` | `--next` |
-| `nfts list-by-contract` | `--next` |
-| `nfts list-by-account` | `--next` |
-| `listings all` | `--next` |
-| `listings best` | `--next` |
-| `offers all` | `--next` |
-| `offers collection` | `--next` |
-| `offers traits` | `--next` |
-| `events list` | `--next` |
-| `events by-account` | `--next` |
-| `events by-collection` | `--next` |
-| `events by-nft` | `--next` |
-| `tokens trending` | `--next` |
-| `tokens top` | `--next` |
+- `collections list`
+- `nfts list-by-collection`
+- `nfts list-by-contract`
+- `nfts list-by-account`
+- `listings all`
+- `listings best`
+- `offers all`
+- `offers collection`
+- `offers traits`
+- `events list`
+- `events by-account`
+- `events by-collection`
+- `events by-nft`
+- `tokens trending`
+- `tokens top`
 
 > **Note:** Search commands (`search collections`, `search nfts`, `search tokens`, `search accounts`) do not support cursor-based pagination. The underlying GraphQL API returns a flat list with no `next` cursor.
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -23,7 +23,6 @@ opensea tokens trending --limit 5 --next "abc123..."
 | Command | Cursor flag |
 |---|---|
 | `collections list` | `--next` |
-
 | `nfts list-by-collection` | `--next` |
 | `nfts list-by-contract` | `--next` |
 | `nfts list-by-account` | `--next` |


### PR DESCRIPTION
## Summary
- Remove stray blank line after the first table row in `docs/pagination.md` that broke the markdown table, causing all remaining rows to render as loose pipe-delimited text

## Test plan
- [ ] Verify the table renders correctly on GitHub by previewing this PR's diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
