### PR TITLE
feat: add User-Agent header to all HTTP requests (DIS-41)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,12 +1,10 @@
-import { createRequire } from "node:module"
 import type { OpenSeaClientConfig } from "./types/index.js"
 
-const require = createRequire(import.meta.url)
-const { version } = require("../package.json") as { version: string }
+declare const __VERSION__: string
 
 const DEFAULT_BASE_URL = "https://api.opensea.io"
 const DEFAULT_TIMEOUT_MS = 30_000
-const USER_AGENT = `opensea-cli/${version}`
+const USER_AGENT = `opensea-cli/${__VERSION__}`
 
 export class OpenSeaClient {
   private apiKey: string
@@ -21,6 +19,14 @@ export class OpenSeaClient {
     this.defaultChain = config.chain ?? "ethereum"
     this.timeoutMs = config.timeout ?? DEFAULT_TIMEOUT_MS
     this.verbose = config.verbose ?? false
+  }
+
+  private get defaultHeaders(): Record<string, string> {
+    return {
+      Accept: "application/json",
+      "User-Agent": USER_AGENT,
+      "x-api-key": this.apiKey,
+    }
   }
 
   async get<T>(path: string, params?: Record<string, unknown>): Promise<T> {
@@ -40,11 +46,7 @@ export class OpenSeaClient {
 
     const response = await fetch(url.toString(), {
       method: "GET",
-      headers: {
-        Accept: "application/json",
-        "User-Agent": USER_AGENT,
-        "x-api-key": this.apiKey,
-      },
+      headers: this.defaultHeaders,
       signal: AbortSignal.timeout(this.timeoutMs),
     })
 
@@ -75,11 +77,7 @@ export class OpenSeaClient {
       }
     }
 
-    const headers: Record<string, string> = {
-      Accept: "application/json",
-      "User-Agent": USER_AGENT,
-      "x-api-key": this.apiKey,
-    }
+    const headers: Record<string, string> = { ...this.defaultHeaders }
 
     if (body) {
       headers["Content-Type"] = "application/json"

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,12 +1,10 @@
-import { createRequire } from "node:module"
 import type { OpenSeaClientConfig } from "./types/index.js"
 
-const require = createRequire(import.meta.url)
-const { version } = require("../package.json") as { version: string }
+declare const __VERSION__: string
 
 const DEFAULT_BASE_URL = "https://api.opensea.io"
 const DEFAULT_TIMEOUT_MS = 30_000
-const USER_AGENT = `opensea-cli/${version}`
+const USER_AGENT = `opensea-cli/${__VERSION__}`
 
 export class OpenSeaClient {
   private apiKey: string

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,12 @@
+import { createRequire } from "node:module"
 import type { OpenSeaClientConfig } from "./types/index.js"
+
+const require = createRequire(import.meta.url)
+const { version } = require("../package.json") as { version: string }
 
 const DEFAULT_BASE_URL = "https://api.opensea.io"
 const DEFAULT_TIMEOUT_MS = 30_000
+const USER_AGENT = `opensea-cli/${version}`
 
 export class OpenSeaClient {
   private apiKey: string
@@ -37,6 +42,7 @@ export class OpenSeaClient {
       method: "GET",
       headers: {
         Accept: "application/json",
+        "User-Agent": USER_AGENT,
         "x-api-key": this.apiKey,
       },
       signal: AbortSignal.timeout(this.timeoutMs),
@@ -71,6 +77,7 @@ export class OpenSeaClient {
 
     const headers: Record<string, string> = {
       Accept: "application/json",
+      "User-Agent": USER_AGENT,
       "x-api-key": this.apiKey,
     }
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -41,7 +41,7 @@ describe("OpenSeaClient", () => {
           method: "GET",
           headers: expect.objectContaining({
             Accept: "application/json",
-            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+\.\d+\.\d+/),
+            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+\.\d+\.\d+$/),
             "x-api-key": "test-key",
           }),
         }),
@@ -96,7 +96,7 @@ describe("OpenSeaClient", () => {
           method: "POST",
           headers: expect.objectContaining({
             Accept: "application/json",
-            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+\.\d+\.\d+/),
+            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+\.\d+\.\d+$/),
             "x-api-key": "test-key",
           }),
         }),
@@ -116,7 +116,7 @@ describe("OpenSeaClient", () => {
           headers: expect.objectContaining({
             Accept: "application/json",
             "Content-Type": "application/json",
-            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+\.\d+\.\d+/),
+            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+\.\d+\.\d+$/),
             "x-api-key": "test-key",
           }),
           body: JSON.stringify({ name: "test" }),

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -39,10 +39,11 @@ describe("OpenSeaClient", () => {
         "https://api.opensea.io/api/v2/test",
         expect.objectContaining({
           method: "GET",
-          headers: {
+          headers: expect.objectContaining({
             Accept: "application/json",
+            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+/),
             "x-api-key": "test-key",
-          },
+          }),
         }),
       )
       expect(result).toEqual(mockResponse)
@@ -93,10 +94,11 @@ describe("OpenSeaClient", () => {
         "https://api.opensea.io/api/v2/refresh",
         expect.objectContaining({
           method: "POST",
-          headers: {
+          headers: expect.objectContaining({
             Accept: "application/json",
+            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+/),
             "x-api-key": "test-key",
-          },
+          }),
         }),
       )
       expect(result).toEqual(mockResponse)
@@ -111,11 +113,12 @@ describe("OpenSeaClient", () => {
         "https://api.opensea.io/api/v2/create",
         expect.objectContaining({
           method: "POST",
-          headers: {
+          headers: expect.objectContaining({
             Accept: "application/json",
             "Content-Type": "application/json",
+            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+/),
             "x-api-key": "test-key",
-          },
+          }),
           body: JSON.stringify({ name: "test" }),
         }),
       )

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -41,7 +41,7 @@ describe("OpenSeaClient", () => {
           method: "GET",
           headers: expect.objectContaining({
             Accept: "application/json",
-            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+/),
+            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+\.\d+\.\d+/),
             "x-api-key": "test-key",
           }),
         }),
@@ -96,7 +96,7 @@ describe("OpenSeaClient", () => {
           method: "POST",
           headers: expect.objectContaining({
             Accept: "application/json",
-            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+/),
+            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+\.\d+\.\d+/),
             "x-api-key": "test-key",
           }),
         }),
@@ -116,7 +116,7 @@ describe("OpenSeaClient", () => {
           headers: expect.objectContaining({
             Accept: "application/json",
             "Content-Type": "application/json",
-            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+/),
+            "User-Agent": expect.stringMatching(/^opensea-cli\/\d+\.\d+\.\d+/),
             "x-api-key": "test-key",
           }),
           body: JSON.stringify({ name: "test" }),

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,11 @@
+import { readFileSync } from "node:fs"
 import { defineConfig } from "tsup"
+
+const { version } = JSON.parse(readFileSync("package.json", "utf-8")) as {
+  version: string
+}
+
+const define = { __VERSION__: JSON.stringify(version) }
 
 export default defineConfig([
   {
@@ -7,6 +14,7 @@ export default defineConfig([
     clean: true,
     sourcemap: true,
     target: "node18",
+    define,
     banner: {
       js: "#!/usr/bin/env node",
     },
@@ -17,5 +25,6 @@ export default defineConfig([
     dts: true,
     sourcemap: true,
     target: "node18",
+    define,
   },
 ])

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,9 @@
+import { readFileSync } from "node:fs"
 import { defineConfig } from "tsup"
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8")) as {
+  version: string
+}
 
 export default defineConfig([
   {
@@ -7,6 +12,9 @@ export default defineConfig([
     clean: true,
     sourcemap: true,
     target: "node18",
+    define: {
+      __VERSION__: JSON.stringify(pkg.version),
+    },
     banner: {
       js: "#!/usr/bin/env node",
     },
@@ -17,5 +25,8 @@ export default defineConfig([
     dts: true,
     sourcemap: true,
     target: "node18",
+    define: {
+      __VERSION__: JSON.stringify(pkg.version),
+    },
   },
 ])

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,14 @@
+import { readFileSync } from "node:fs"
 import { defineConfig } from "vitest/config"
 
+const { version } = JSON.parse(readFileSync("package.json", "utf-8")) as {
+  version: string
+}
+
 export default defineConfig({
+  define: {
+    __VERSION__: JSON.stringify(version),
+  },
   test: {
     coverage: {
       provider: "v8",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,14 @@
+import { readFileSync } from "node:fs"
 import { defineConfig } from "vitest/config"
 
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8")) as {
+  version: string
+}
+
 export default defineConfig({
+  define: {
+    __VERSION__: JSON.stringify(pkg.version),
+  },
   test: {
     coverage: {
       provider: "v8",


### PR DESCRIPTION
# Add User-Agent header to all HTTP requests

## Summary

Adds a `User-Agent: opensea-cli/<version>` header to every HTTP request made by `OpenSeaClient`, enabling server-side traffic segmentation by channel (CLI vs MCP vs other consumers) in Datadog/analytics.

- Version is injected at **build time** via tsup's `define` option (`__VERSION__`), avoiding any runtime dependency on file-system layout
- Both `tsup.config.ts` and `vitest.config.ts` read `package.json` and define `__VERSION__` so the constant is available in builds and tests
- A private `defaultHeaders` getter centralizes the shared header set (`Accept`, `User-Agent`, `x-api-key`), used by both `get()` and `post()`
- Test assertions use `expect.objectContaining` with a strictly-anchored regex (`/^opensea-cli\/\d+\.\d+\.\d+$/`) to validate the header value

**Confidence: 🟢 High** — small, well-scoped change. Lint, type-check, and all 151 tests pass locally.

## Updates since last revision

Addressed review feedback from @ckorhonen:
1. **Build-time version injection** — replaced `createRequire`/`require("../package.json")` with tsup `define: { __VERSION__: JSON.stringify(pkg.version) }`. Eliminates the CJS `require()` call in an ESM-only codebase and removes runtime dependency on `dist/` ↔ `package.json` relative path.
2. **Anchored test regex** — added `$` to regex end (`/^opensea-cli\/\d+\.\d+\.\d+$/`) to reject malformed values like `opensea-cli/1.2.3-garbage`.
3. **Extracted `defaultHeaders` getter** — private getter on `OpenSeaClient` removes header duplication between `get()` and `post()`.

## Review & Testing Checklist for Human

- [ ] Verify `__VERSION__` is correctly inlined after build: run `npm run build && grep 'opensea-cli/' dist/index.js` — should show the literal version string (e.g. `opensea-cli/0.4.1`), not `__VERSION__`
- [ ] Confirm the `post()` spread (`{ ...this.defaultHeaders }`) correctly includes `Content-Type` when a body is provided — the test covers this but worth a quick manual check of the logic

### Notes
- Test assertions use `expect.objectContaining` instead of exact header matching to accommodate the new header without breaking if header order changes. This is marginally less strict than before.
- The `$`-anchored regex means pre-release versions (e.g. `1.2.3-beta.1`) would fail the test assertion — this is intentional per reviewer preference for strict semver matching.
- [Linear ticket: DIS-41](https://linear.app/opensea/issue/DIS-41/tracking-add-user-agent-header-to-opensea-cli)
- [Devin Session](https://app.devin.ai/sessions/e3804a158ee04876a26f19d526a445ec)
- Requested by: @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
