### PR TITLE
feat: add opensea health diagnostic command (DIS-144)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import {
   accountsCommand,
   collectionsCommand,
   eventsCommand,
+  healthCommand,
   listingsCommand,
   nftsCommand,
   offersCommand,
@@ -81,6 +82,7 @@ program.addCommand(accountsCommand(getClient, getFormat))
 program.addCommand(tokensCommand(getClient, getFormat))
 program.addCommand(searchCommand(getClient, getFormat))
 program.addCommand(swapsCommand(getClient, getFormat))
+program.addCommand(healthCommand(getClient, getFormat))
 
 async function main() {
   try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -106,6 +106,7 @@ export class OpenSeaClient {
   }
 
   getApiKeyPrefix(): string {
+    if (this.apiKey.length < 8) return "***"
     return `${this.apiKey.slice(0, 4)}...`
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -104,6 +104,10 @@ export class OpenSeaClient {
   getDefaultChain(): string {
     return this.defaultChain
   }
+
+  getApiKeyPrefix(): string {
+    return `${this.apiKey.slice(0, 4)}...`
+  }
 }
 
 export class OpenSeaAPIError extends Error {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1,0 +1,47 @@
+import { Command } from "commander"
+import { OpenSeaAPIError, type OpenSeaClient } from "../client.js"
+import type { OutputFormat } from "../output.js"
+import { formatOutput } from "../output.js"
+import type { HealthResult } from "../types/index.js"
+
+export function healthCommand(
+  getClient: () => OpenSeaClient,
+  getFormat: () => OutputFormat,
+): Command {
+  const cmd = new Command("health")
+    .description("Check API key validity and connectivity")
+    .action(async () => {
+      const client = getClient()
+      const keyPrefix = client.getApiKeyPrefix()
+
+      try {
+        await client.get("/api/v2/collections", { limit: 1 })
+        const result: HealthResult = {
+          status: "ok",
+          key_prefix: keyPrefix,
+          message: "API key is valid and connectivity is working",
+        }
+        console.log(formatOutput(result, getFormat()))
+      } catch (error) {
+        let message: string
+        if (error instanceof OpenSeaAPIError) {
+          message =
+            error.statusCode === 401 || error.statusCode === 403
+              ? `Authentication failed (${error.statusCode}): ${error.responseBody}`
+              : `API error (${error.statusCode}): ${error.responseBody}`
+        } else {
+          message = `Network error: ${(error as Error).message}`
+        }
+
+        const result: HealthResult = {
+          status: "error",
+          key_prefix: keyPrefix,
+          message,
+        }
+        console.log(formatOutput(result, getFormat()))
+        process.exit(1)
+      }
+    })
+
+  return cmd
+}

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1,44 +1,20 @@
 import { Command } from "commander"
-import { OpenSeaAPIError, type OpenSeaClient } from "../client.js"
+import type { OpenSeaClient } from "../client.js"
+import { checkHealth } from "../health.js"
 import type { OutputFormat } from "../output.js"
 import { formatOutput } from "../output.js"
-import type { HealthResult } from "../types/index.js"
 
 export function healthCommand(
   getClient: () => OpenSeaClient,
   getFormat: () => OutputFormat,
 ): Command {
   const cmd = new Command("health")
-    .description("Check API key validity and connectivity")
+    .description("Check API connectivity")
     .action(async () => {
       const client = getClient()
-      const keyPrefix = client.getApiKeyPrefix()
-
-      try {
-        await client.get("/api/v2/collections", { limit: 1 })
-        const result: HealthResult = {
-          status: "ok",
-          key_prefix: keyPrefix,
-          message: "API key is valid and connectivity is working",
-        }
-        console.log(formatOutput(result, getFormat()))
-      } catch (error) {
-        let message: string
-        if (error instanceof OpenSeaAPIError) {
-          message =
-            error.statusCode === 401 || error.statusCode === 403
-              ? `Authentication failed (${error.statusCode}): ${error.responseBody}`
-              : `API error (${error.statusCode}): ${error.responseBody}`
-        } else {
-          message = `Network error: ${(error as Error).message}`
-        }
-
-        const result: HealthResult = {
-          status: "error",
-          key_prefix: keyPrefix,
-          message,
-        }
-        console.log(formatOutput(result, getFormat()))
+      const result = await checkHealth(client)
+      console.log(formatOutput(result, getFormat()))
+      if (result.status === "error") {
         process.exit(1)
       }
     })

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -9,7 +9,7 @@ export function healthCommand(
   getFormat: () => OutputFormat,
 ): Command {
   const cmd = new Command("health")
-    .description("Check API connectivity")
+    .description("Check API connectivity and authentication")
     .action(async () => {
       const client = getClient()
       const result = await checkHealth(client)

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -15,7 +15,7 @@ export function healthCommand(
       const result = await checkHealth(client)
       console.log(formatOutput(result, getFormat()))
       if (result.status === "error") {
-        process.exit(1)
+        process.exit(result.rate_limited ? 3 : 1)
       }
     })
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,7 @@
 export { accountsCommand } from "./accounts.js"
 export { collectionsCommand } from "./collections.js"
 export { eventsCommand } from "./events.js"
+export { healthCommand } from "./health.js"
 export { listingsCommand } from "./listings.js"
 export { nftsCommand } from "./nfts.js"
 export { offersCommand } from "./offers.js"

--- a/src/health.ts
+++ b/src/health.ts
@@ -12,7 +12,10 @@ export async function checkHealth(
   } catch (error) {
     let message: string
     if (error instanceof OpenSeaAPIError) {
-      message = `API error (${error.statusCode}): ${error.responseBody}`
+      message =
+        error.statusCode === 429
+          ? "Rate limited: too many requests"
+          : `API error (${error.statusCode}): ${error.responseBody}`
     } else {
       message = `Network error: ${(error as Error).message}`
     }
@@ -20,6 +23,8 @@ export async function checkHealth(
       status: "error",
       key_prefix: keyPrefix,
       authenticated: false,
+      rate_limited:
+        error instanceof OpenSeaAPIError && error.statusCode === 429,
       message,
     }
   }
@@ -33,18 +38,28 @@ export async function checkHealth(
       status: "ok",
       key_prefix: keyPrefix,
       authenticated: true,
+      rate_limited: false,
       message: "Connectivity and authentication are working",
     }
   } catch (error) {
-    if (
-      error instanceof OpenSeaAPIError &&
-      (error.statusCode === 401 || error.statusCode === 403)
-    ) {
-      return {
-        status: "error",
-        key_prefix: keyPrefix,
-        authenticated: false,
-        message: `Authentication failed (${error.statusCode}): invalid API key`,
+    if (error instanceof OpenSeaAPIError) {
+      if (error.statusCode === 429) {
+        return {
+          status: "error",
+          key_prefix: keyPrefix,
+          authenticated: false,
+          rate_limited: true,
+          message: "Rate limited: too many requests",
+        }
+      }
+      if (error.statusCode === 401 || error.statusCode === 403) {
+        return {
+          status: "error",
+          key_prefix: keyPrefix,
+          authenticated: false,
+          rate_limited: false,
+          message: `Authentication failed (${error.statusCode}): invalid API key`,
+        }
       }
     }
     // Non-auth error on listings endpoint — connectivity works but auth is unverified
@@ -52,6 +67,7 @@ export async function checkHealth(
       status: "ok",
       key_prefix: keyPrefix,
       authenticated: false,
+      rate_limited: false,
       message:
         "Connectivity is working but authentication could not be verified",
     }

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,31 @@
+import { OpenSeaAPIError, type OpenSeaClient } from "./client.js"
+import type { HealthResult } from "./types/index.js"
+
+export async function checkHealth(
+  client: OpenSeaClient,
+): Promise<HealthResult> {
+  const keyPrefix = client.getApiKeyPrefix()
+  try {
+    await client.get("/api/v2/collections", { limit: 1 })
+    return {
+      status: "ok",
+      key_prefix: keyPrefix,
+      message: "Connectivity is working",
+    }
+  } catch (error) {
+    let message: string
+    if (error instanceof OpenSeaAPIError) {
+      message =
+        error.statusCode === 401 || error.statusCode === 403
+          ? `Authentication failed (${error.statusCode}): ${error.responseBody}`
+          : `API error (${error.statusCode}): ${error.responseBody}`
+    } else {
+      message = `Network error: ${(error as Error).message}`
+    }
+    return {
+      status: "error",
+      key_prefix: keyPrefix,
+      message,
+    }
+  }
+}

--- a/src/health.ts
+++ b/src/health.ts
@@ -47,12 +47,13 @@ export async function checkHealth(
         message: `Authentication failed (${error.statusCode}): invalid API key`,
       }
     }
-    // Non-auth error on events endpoint — connectivity works but auth is unverified
+    // Non-auth error on listings endpoint — connectivity works but auth is unverified
     return {
       status: "ok",
       key_prefix: keyPrefix,
       authenticated: false,
-      message: "Connectivity is working but authentication could not be verified",
+      message:
+        "Connectivity is working but authentication could not be verified",
     }
   }
 }

--- a/src/health.ts
+++ b/src/health.ts
@@ -5,27 +5,54 @@ export async function checkHealth(
   client: OpenSeaClient,
 ): Promise<HealthResult> {
   const keyPrefix = client.getApiKeyPrefix()
+
+  // Step 1: Check basic connectivity with a public endpoint
   try {
     await client.get("/api/v2/collections", { limit: 1 })
-    return {
-      status: "ok",
-      key_prefix: keyPrefix,
-      message: "Connectivity is working",
-    }
   } catch (error) {
     let message: string
     if (error instanceof OpenSeaAPIError) {
-      message =
-        error.statusCode === 401 || error.statusCode === 403
-          ? `Authentication failed (${error.statusCode}): ${error.responseBody}`
-          : `API error (${error.statusCode}): ${error.responseBody}`
+      message = `API error (${error.statusCode}): ${error.responseBody}`
     } else {
       message = `Network error: ${(error as Error).message}`
     }
     return {
       status: "error",
       key_prefix: keyPrefix,
+      authenticated: false,
       message,
+    }
+  }
+
+  // Step 2: Validate authentication with an endpoint that requires a valid API key
+  try {
+    await client.get("/api/v2/listings/collection/boredapeyachtclub/all", {
+      limit: 1,
+    })
+    return {
+      status: "ok",
+      key_prefix: keyPrefix,
+      authenticated: true,
+      message: "Connectivity and authentication are working",
+    }
+  } catch (error) {
+    if (
+      error instanceof OpenSeaAPIError &&
+      (error.statusCode === 401 || error.statusCode === 403)
+    ) {
+      return {
+        status: "error",
+        key_prefix: keyPrefix,
+        authenticated: false,
+        message: `Authentication failed (${error.statusCode}): invalid API key`,
+      }
+    }
+    // Non-auth error on events endpoint — connectivity works but auth is unverified
+    return {
+      status: "ok",
+      key_prefix: keyPrefix,
+      authenticated: false,
+      message: "Connectivity is working but authentication could not be verified",
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { OpenSeaAPIError, OpenSeaClient } from "./client.js"
+export { checkHealth } from "./health.js"
 export type { OutputFormat } from "./output.js"
 export { formatOutput } from "./output.js"
 export { OpenSeaCLI } from "./sdk.js"

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,4 +1,5 @@
-import { OpenSeaAPIError, OpenSeaClient } from "./client.js"
+import { OpenSeaClient } from "./client.js"
+import { checkHealth } from "./health.js"
 import type {
   Account,
   AssetEvent,
@@ -392,29 +393,6 @@ class HealthAPI {
   constructor(private client: OpenSeaClient) {}
 
   async check(): Promise<HealthResult> {
-    const keyPrefix = this.client.getApiKeyPrefix()
-    try {
-      await this.client.get("/api/v2/collections", { limit: 1 })
-      return {
-        status: "ok",
-        key_prefix: keyPrefix,
-        message: "API key is valid and connectivity is working",
-      }
-    } catch (error) {
-      let message: string
-      if (error instanceof OpenSeaAPIError) {
-        message =
-          error.statusCode === 401 || error.statusCode === 403
-            ? `Authentication failed (${error.statusCode}): ${error.responseBody}`
-            : `API error (${error.statusCode}): ${error.responseBody}`
-      } else {
-        message = `Network error: ${(error as Error).message}`
-      }
-      return {
-        status: "error",
-        key_prefix: keyPrefix,
-        message,
-      }
-    }
+    return checkHealth(this.client)
   }
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,4 +1,4 @@
-import { OpenSeaClient } from "./client.js"
+import { OpenSeaAPIError, OpenSeaClient } from "./client.js"
 import type {
   Account,
   AssetEvent,
@@ -9,6 +9,7 @@ import type {
   Contract,
   EventType,
   GetTraitsResponse,
+  HealthResult,
   Listing,
   NFT,
   Offer,
@@ -32,6 +33,7 @@ export class OpenSeaCLI {
   readonly tokens: TokensAPI
   readonly search: SearchAPI
   readonly swaps: SwapsAPI
+  readonly health: HealthAPI
 
   constructor(config: OpenSeaClientConfig) {
     this.client = new OpenSeaClient(config)
@@ -44,6 +46,7 @@ export class OpenSeaCLI {
     this.tokens = new TokensAPI(this.client)
     this.search = new SearchAPI(this.client)
     this.swaps = new SwapsAPI(this.client)
+    this.health = new HealthAPI(this.client)
   }
 }
 
@@ -382,5 +385,36 @@ class SwapsAPI {
       slippage: options.slippage,
       recipient: options.recipient,
     })
+  }
+}
+
+class HealthAPI {
+  constructor(private client: OpenSeaClient) {}
+
+  async check(): Promise<HealthResult> {
+    const keyPrefix = this.client.getApiKeyPrefix()
+    try {
+      await this.client.get("/api/v2/collections", { limit: 1 })
+      return {
+        status: "ok",
+        key_prefix: keyPrefix,
+        message: "API key is valid and connectivity is working",
+      }
+    } catch (error) {
+      let message: string
+      if (error instanceof OpenSeaAPIError) {
+        message =
+          error.statusCode === 401 || error.statusCode === 403
+            ? `Authentication failed (${error.statusCode}): ${error.responseBody}`
+            : `API error (${error.statusCode}): ${error.responseBody}`
+      } else {
+        message = `Network error: ${(error as Error).message}`
+      }
+      return {
+        status: "error",
+        key_prefix: keyPrefix,
+        message,
+      }
+    }
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,3 +14,9 @@ export interface CommandOptions {
   format?: "json" | "table"
   raw?: boolean
 }
+
+export type HealthResult = {
+  status: "ok" | "error"
+  key_prefix: string
+  message: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,5 +18,6 @@ export interface CommandOptions {
 export interface HealthResult {
   status: "ok" | "error"
   key_prefix: string
+  authenticated: boolean
   message: string
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,7 +15,7 @@ export interface CommandOptions {
   raw?: boolean
 }
 
-export type HealthResult = {
+export interface HealthResult {
   status: "ok" | "error"
   key_prefix: string
   message: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,5 +19,6 @@ export interface HealthResult {
   status: "ok" | "error"
   key_prefix: string
   authenticated: boolean
+  rate_limited: boolean
   message: string
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -215,6 +215,17 @@ describe("OpenSeaClient", () => {
       expect(client.getDefaultChain()).toBe("ethereum")
     })
   })
+
+  describe("getApiKeyPrefix", () => {
+    it("returns first 4 characters followed by ellipsis", () => {
+      expect(client.getApiKeyPrefix()).toBe("test...")
+    })
+
+    it("handles short API keys", () => {
+      const shortKeyClient = new OpenSeaClient({ apiKey: "ab" })
+      expect(shortKeyClient.getApiKeyPrefix()).toBe("ab...")
+    })
+  })
 })
 
 describe("OpenSeaAPIError", () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -221,9 +221,9 @@ describe("OpenSeaClient", () => {
       expect(client.getApiKeyPrefix()).toBe("test...")
     })
 
-    it("handles short API keys", () => {
+    it("masks short API keys", () => {
       const shortKeyClient = new OpenSeaClient({ apiKey: "ab" })
-      expect(shortKeyClient.getApiKeyPrefix()).toBe("ab...")
+      expect(shortKeyClient.getApiKeyPrefix()).toBe("***")
     })
   })
 })

--- a/test/commands/health.test.ts
+++ b/test/commands/health.test.ts
@@ -19,8 +19,8 @@ describe("healthCommand", () => {
     expect(cmd.name()).toBe("health")
   })
 
-  it("outputs ok status when API call succeeds", async () => {
-    ctx.mockClient.get.mockResolvedValue({ collections: [] })
+  it("outputs ok status when both connectivity and auth succeed", async () => {
+    ctx.mockClient.get.mockResolvedValue({})
 
     const cmd = healthCommand(ctx.getClient, ctx.getFormat)
     await cmd.parseAsync([], { from: "user" })
@@ -28,32 +28,19 @@ describe("healthCommand", () => {
     expect(ctx.mockClient.get).toHaveBeenCalledWith("/api/v2/collections", {
       limit: 1,
     })
+    expect(ctx.mockClient.get).toHaveBeenCalledWith("/api/v2/listings/collection/boredapeyachtclub/all", {
+      limit: 1,
+    })
     const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
     expect(output.status).toBe("ok")
     expect(output.key_prefix).toBe("test...")
-    expect(output.message).toBe("Connectivity is working")
-  })
-
-  it("outputs error status on authentication failure", async () => {
-    ctx.mockClient.get.mockRejectedValue(
-      new OpenSeaAPIError(401, "Unauthorized", "/api/v2/collections"),
+    expect(output.authenticated).toBe(true)
+    expect(output.message).toBe(
+      "Connectivity and authentication are working",
     )
-
-    const mockExit = vi
-      .spyOn(process, "exit")
-      .mockImplementation(() => undefined as never)
-
-    const cmd = healthCommand(ctx.getClient, ctx.getFormat)
-    await cmd.parseAsync([], { from: "user" })
-
-    const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
-    expect(output.status).toBe("error")
-    expect(output.key_prefix).toBe("test...")
-    expect(output.message).toContain("Authentication failed (401)")
-    expect(mockExit).toHaveBeenCalledWith(1)
   })
 
-  it("outputs error status on other API errors", async () => {
+  it("outputs error status when connectivity fails", async () => {
     ctx.mockClient.get.mockRejectedValue(
       new OpenSeaAPIError(500, "Internal Server Error", "/api/v2/collections"),
     )
@@ -67,7 +54,29 @@ describe("healthCommand", () => {
 
     const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
     expect(output.status).toBe("error")
+    expect(output.authenticated).toBe(false)
     expect(output.message).toContain("API error (500)")
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it("outputs error status when auth fails (401)", async () => {
+    ctx.mockClient.get
+      .mockResolvedValueOnce({}) // connectivity ok
+      .mockRejectedValueOnce(
+        new OpenSeaAPIError(401, "Unauthorized", "/api/v2/listings/collection/boredapeyachtclub/all"),
+      )
+
+    const mockExit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never)
+
+    const cmd = healthCommand(ctx.getClient, ctx.getFormat)
+    await cmd.parseAsync([], { from: "user" })
+
+    const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
+    expect(output.status).toBe("error")
+    expect(output.authenticated).toBe(false)
+    expect(output.message).toContain("Authentication failed (401)")
     expect(mockExit).toHaveBeenCalledWith(1)
   })
 
@@ -85,5 +94,21 @@ describe("healthCommand", () => {
     expect(output.status).toBe("error")
     expect(output.message).toContain("Network error: fetch failed")
     expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it("reports ok with unverified auth when events endpoint has non-auth error", async () => {
+    ctx.mockClient.get
+      .mockResolvedValueOnce({}) // connectivity ok
+      .mockRejectedValueOnce(
+        new OpenSeaAPIError(500, "Server Error", "/api/v2/listings/collection/boredapeyachtclub/all"),
+      )
+
+    const cmd = healthCommand(ctx.getClient, ctx.getFormat)
+    await cmd.parseAsync([], { from: "user" })
+
+    const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
+    expect(output.status).toBe("ok")
+    expect(output.authenticated).toBe(false)
+    expect(output.message).toContain("could not be verified")
   })
 })

--- a/test/commands/health.test.ts
+++ b/test/commands/health.test.ts
@@ -28,16 +28,17 @@ describe("healthCommand", () => {
     expect(ctx.mockClient.get).toHaveBeenCalledWith("/api/v2/collections", {
       limit: 1,
     })
-    expect(ctx.mockClient.get).toHaveBeenCalledWith("/api/v2/listings/collection/boredapeyachtclub/all", {
-      limit: 1,
-    })
+    expect(ctx.mockClient.get).toHaveBeenCalledWith(
+      "/api/v2/listings/collection/boredapeyachtclub/all",
+      {
+        limit: 1,
+      },
+    )
     const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
     expect(output.status).toBe("ok")
     expect(output.key_prefix).toBe("test...")
     expect(output.authenticated).toBe(true)
-    expect(output.message).toBe(
-      "Connectivity and authentication are working",
-    )
+    expect(output.message).toBe("Connectivity and authentication are working")
   })
 
   it("outputs error status when connectivity fails", async () => {
@@ -63,7 +64,11 @@ describe("healthCommand", () => {
     ctx.mockClient.get
       .mockResolvedValueOnce({}) // connectivity ok
       .mockRejectedValueOnce(
-        new OpenSeaAPIError(401, "Unauthorized", "/api/v2/listings/collection/boredapeyachtclub/all"),
+        new OpenSeaAPIError(
+          401,
+          "Unauthorized",
+          "/api/v2/listings/collection/boredapeyachtclub/all",
+        ),
       )
 
     const mockExit = vi
@@ -100,7 +105,11 @@ describe("healthCommand", () => {
     ctx.mockClient.get
       .mockResolvedValueOnce({}) // connectivity ok
       .mockRejectedValueOnce(
-        new OpenSeaAPIError(500, "Server Error", "/api/v2/listings/collection/boredapeyachtclub/all"),
+        new OpenSeaAPIError(
+          500,
+          "Server Error",
+          "/api/v2/listings/collection/boredapeyachtclub/all",
+        ),
       )
 
     const cmd = healthCommand(ctx.getClient, ctx.getFormat)

--- a/test/commands/health.test.ts
+++ b/test/commands/health.test.ts
@@ -101,7 +101,7 @@ describe("healthCommand", () => {
     expect(mockExit).toHaveBeenCalledWith(1)
   })
 
-  it("reports ok with unverified auth when events endpoint has non-auth error", async () => {
+  it("reports ok with unverified auth when listings endpoint has non-auth error", async () => {
     ctx.mockClient.get
       .mockResolvedValueOnce({}) // connectivity ok
       .mockRejectedValueOnce(
@@ -119,5 +119,24 @@ describe("healthCommand", () => {
     expect(output.status).toBe("ok")
     expect(output.authenticated).toBe(false)
     expect(output.message).toContain("could not be verified")
+  })
+
+  it("exits with code 3 on rate limit (429)", async () => {
+    ctx.mockClient.get.mockRejectedValue(
+      new OpenSeaAPIError(429, "Too Many Requests", "/api/v2/collections"),
+    )
+
+    const mockExit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never)
+
+    const cmd = healthCommand(ctx.getClient, ctx.getFormat)
+    await cmd.parseAsync([], { from: "user" })
+
+    const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
+    expect(output.status).toBe("error")
+    expect(output.rate_limited).toBe(true)
+    expect(output.message).toContain("Rate limited")
+    expect(mockExit).toHaveBeenCalledWith(3)
   })
 })

--- a/test/commands/health.test.ts
+++ b/test/commands/health.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { OpenSeaAPIError } from "../../src/client.js"
+import { healthCommand } from "../../src/commands/health.js"
+import { type CommandTestContext, createCommandTestContext } from "../mocks.js"
+
+describe("healthCommand", () => {
+  let ctx: CommandTestContext
+  let mockGetApiKeyPrefix: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    ctx = createCommandTestContext()
+    mockGetApiKeyPrefix = vi.fn().mockReturnValue("test...")
+    ;(ctx.mockClient as Record<string, unknown>).getApiKeyPrefix =
+      mockGetApiKeyPrefix
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("creates command with correct name", () => {
+    const cmd = healthCommand(ctx.getClient, ctx.getFormat)
+    expect(cmd.name()).toBe("health")
+  })
+
+  it("outputs ok status when API call succeeds", async () => {
+    ctx.mockClient.get.mockResolvedValue({ collections: [] })
+
+    const cmd = healthCommand(ctx.getClient, ctx.getFormat)
+    await cmd.parseAsync([], { from: "user" })
+
+    expect(ctx.mockClient.get).toHaveBeenCalledWith("/api/v2/collections", {
+      limit: 1,
+    })
+    const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
+    expect(output.status).toBe("ok")
+    expect(output.key_prefix).toBe("test...")
+    expect(output.message).toBe("API key is valid and connectivity is working")
+  })
+
+  it("outputs error status on authentication failure", async () => {
+    ctx.mockClient.get.mockRejectedValue(
+      new OpenSeaAPIError(401, "Unauthorized", "/api/v2/collections"),
+    )
+
+    const mockExit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never)
+
+    const cmd = healthCommand(ctx.getClient, ctx.getFormat)
+    await cmd.parseAsync([], { from: "user" })
+
+    const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
+    expect(output.status).toBe("error")
+    expect(output.key_prefix).toBe("test...")
+    expect(output.message).toContain("Authentication failed (401)")
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it("outputs error status on other API errors", async () => {
+    ctx.mockClient.get.mockRejectedValue(
+      new OpenSeaAPIError(500, "Internal Server Error", "/api/v2/collections"),
+    )
+
+    const mockExit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never)
+
+    const cmd = healthCommand(ctx.getClient, ctx.getFormat)
+    await cmd.parseAsync([], { from: "user" })
+
+    const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
+    expect(output.status).toBe("error")
+    expect(output.message).toContain("API error (500)")
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it("outputs error status on network errors", async () => {
+    ctx.mockClient.get.mockRejectedValue(new TypeError("fetch failed"))
+
+    const mockExit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never)
+
+    const cmd = healthCommand(ctx.getClient, ctx.getFormat)
+    await cmd.parseAsync([], { from: "user" })
+
+    const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
+    expect(output.status).toBe("error")
+    expect(output.message).toContain("Network error: fetch failed")
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+})

--- a/test/commands/health.test.ts
+++ b/test/commands/health.test.ts
@@ -5,13 +5,9 @@ import { type CommandTestContext, createCommandTestContext } from "../mocks.js"
 
 describe("healthCommand", () => {
   let ctx: CommandTestContext
-  let mockGetApiKeyPrefix: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     ctx = createCommandTestContext()
-    mockGetApiKeyPrefix = vi.fn().mockReturnValue("test...")
-    ;(ctx.mockClient as Record<string, unknown>).getApiKeyPrefix =
-      mockGetApiKeyPrefix
   })
 
   afterEach(() => {
@@ -35,7 +31,7 @@ describe("healthCommand", () => {
     const output = JSON.parse(ctx.consoleSpy.mock.calls[0][0] as string)
     expect(output.status).toBe("ok")
     expect(output.key_prefix).toBe("test...")
-    expect(output.message).toBe("API key is valid and connectivity is working")
+    expect(output.message).toBe("Connectivity is working")
   })
 
   it("outputs error status on authentication failure", async () => {

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -5,6 +5,7 @@ import type { OutputFormat } from "../src/output.js"
 export type MockClient = {
   get: Mock
   post: Mock
+  getApiKeyPrefix: Mock
 }
 
 export type CommandTestContext = {
@@ -18,6 +19,7 @@ export function createCommandTestContext(): CommandTestContext {
   const mockClient: MockClient = {
     get: vi.fn(),
     post: vi.fn(),
+    getApiKeyPrefix: vi.fn().mockReturnValue("test..."),
   }
   const getClient = () => mockClient as unknown as OpenSeaClient
   const getFormat = () => "json" as OutputFormat

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -415,28 +415,24 @@ describe("OpenSeaCLI", () => {
   })
 
   describe("health", () => {
-    it("check returns ok when API call succeeds", async () => {
-      mockGet.mockResolvedValue({ collections: [] })
+    it("check returns ok with auth when both calls succeed", async () => {
+      mockGet.mockResolvedValue({})
       const result = await sdk.health.check()
       expect(mockGet).toHaveBeenCalledWith("/api/v2/collections", {
         limit: 1,
       })
+      expect(mockGet).toHaveBeenCalledWith("/api/v2/listings/collection/boredapeyachtclub/all", {
+        limit: 1,
+      })
       expect(result.status).toBe("ok")
+      expect(result.authenticated).toBe(true)
       expect(result.key_prefix).toBe("test...")
-      expect(result.message).toBe("Connectivity is working")
-    })
-
-    it("check returns error on authentication failure", async () => {
-      mockGet.mockRejectedValue(
-        new OpenSeaAPIError(401, "Unauthorized", "/api/v2/collections"),
+      expect(result.message).toBe(
+        "Connectivity and authentication are working",
       )
-      const result = await sdk.health.check()
-      expect(result.status).toBe("error")
-      expect(result.key_prefix).toBe("test...")
-      expect(result.message).toContain("Authentication failed (401)")
     })
 
-    it("check returns error on API error", async () => {
+    it("check returns error when connectivity fails", async () => {
       mockGet.mockRejectedValue(
         new OpenSeaAPIError(
           500,
@@ -446,8 +442,46 @@ describe("OpenSeaCLI", () => {
       )
       const result = await sdk.health.check()
       expect(result.status).toBe("error")
+      expect(result.authenticated).toBe(false)
       expect(result.key_prefix).toBe("test...")
       expect(result.message).toContain("API error (500)")
+    })
+
+    it("check returns error on authentication failure (401)", async () => {
+      mockGet
+        .mockResolvedValueOnce({}) // connectivity ok
+        .mockRejectedValueOnce(
+          new OpenSeaAPIError(401, "Unauthorized", "/api/v2/events"),
+        )
+      const result = await sdk.health.check()
+      expect(result.status).toBe("error")
+      expect(result.authenticated).toBe(false)
+      expect(result.key_prefix).toBe("test...")
+      expect(result.message).toContain("Authentication failed (401)")
+    })
+
+    it("check returns error on authentication failure (403)", async () => {
+      mockGet
+        .mockResolvedValueOnce({}) // connectivity ok
+        .mockRejectedValueOnce(
+          new OpenSeaAPIError(403, "Forbidden", "/api/v2/events"),
+        )
+      const result = await sdk.health.check()
+      expect(result.status).toBe("error")
+      expect(result.authenticated).toBe(false)
+      expect(result.message).toContain("Authentication failed (403)")
+    })
+
+    it("check returns ok with unverified auth on non-auth events error", async () => {
+      mockGet
+        .mockResolvedValueOnce({}) // connectivity ok
+        .mockRejectedValueOnce(
+          new OpenSeaAPIError(500, "Server Error", "/api/v2/events"),
+        )
+      const result = await sdk.health.check()
+      expect(result.status).toBe("ok")
+      expect(result.authenticated).toBe(false)
+      expect(result.message).toContain("could not be verified")
     })
 
     it("check returns error when network fails", async () => {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -7,6 +7,7 @@ vi.mock("../src/client.js", () => {
   MockOpenSeaClient.prototype.get = vi.fn()
   MockOpenSeaClient.prototype.post = vi.fn()
   MockOpenSeaClient.prototype.getDefaultChain = vi.fn(() => "ethereum")
+  MockOpenSeaClient.prototype.getApiKeyPrefix = vi.fn(() => "test...")
   return { OpenSeaClient: MockOpenSeaClient, OpenSeaAPIError: vi.fn() }
 })
 
@@ -36,6 +37,7 @@ describe("OpenSeaCLI", () => {
       expect(sdk.tokens).toBeDefined()
       expect(sdk.search).toBeDefined()
       expect(sdk.swaps).toBeDefined()
+      expect(sdk.health).toBeDefined()
     })
   })
 
@@ -405,6 +407,29 @@ describe("OpenSeaCLI", () => {
         slippage: 0.02,
         recipient: undefined,
       })
+    })
+  })
+
+  describe("health", () => {
+    it("check returns ok when API call succeeds", async () => {
+      mockGet.mockResolvedValue({ collections: [] })
+      const result = await sdk.health.check()
+      expect(mockGet).toHaveBeenCalledWith("/api/v2/collections", {
+        limit: 1,
+      })
+      expect(result.status).toBe("ok")
+      expect(result.key_prefix).toBe("test...")
+      expect(result.message).toBe(
+        "API key is valid and connectivity is working",
+      )
+    })
+
+    it("check returns error when API call fails", async () => {
+      mockGet.mockRejectedValue(new Error("fetch failed"))
+      const result = await sdk.health.check()
+      expect(result.status).toBe("error")
+      expect(result.key_prefix).toBe("test...")
+      expect(result.message).toContain("Network error: fetch failed")
     })
   })
 })

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -1,14 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { OpenSeaClient } from "../src/client.js"
+import { OpenSeaAPIError, OpenSeaClient } from "../src/client.js"
 import { OpenSeaCLI } from "../src/sdk.js"
 
-vi.mock("../src/client.js", () => {
+vi.mock("../src/client.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../src/client.js")>()
   const MockOpenSeaClient = vi.fn()
   MockOpenSeaClient.prototype.get = vi.fn()
   MockOpenSeaClient.prototype.post = vi.fn()
   MockOpenSeaClient.prototype.getDefaultChain = vi.fn(() => "ethereum")
   MockOpenSeaClient.prototype.getApiKeyPrefix = vi.fn(() => "test...")
-  return { OpenSeaClient: MockOpenSeaClient, OpenSeaAPIError: vi.fn() }
+  return {
+    OpenSeaClient: MockOpenSeaClient,
+    OpenSeaAPIError: actual.OpenSeaAPIError,
+  }
 })
 
 describe("OpenSeaCLI", () => {
@@ -419,12 +423,34 @@ describe("OpenSeaCLI", () => {
       })
       expect(result.status).toBe("ok")
       expect(result.key_prefix).toBe("test...")
-      expect(result.message).toBe(
-        "API key is valid and connectivity is working",
-      )
+      expect(result.message).toBe("Connectivity is working")
     })
 
-    it("check returns error when API call fails", async () => {
+    it("check returns error on authentication failure", async () => {
+      mockGet.mockRejectedValue(
+        new OpenSeaAPIError(401, "Unauthorized", "/api/v2/collections"),
+      )
+      const result = await sdk.health.check()
+      expect(result.status).toBe("error")
+      expect(result.key_prefix).toBe("test...")
+      expect(result.message).toContain("Authentication failed (401)")
+    })
+
+    it("check returns error on API error", async () => {
+      mockGet.mockRejectedValue(
+        new OpenSeaAPIError(
+          500,
+          "Internal Server Error",
+          "/api/v2/collections",
+        ),
+      )
+      const result = await sdk.health.check()
+      expect(result.status).toBe("error")
+      expect(result.key_prefix).toBe("test...")
+      expect(result.message).toContain("API error (500)")
+    })
+
+    it("check returns error when network fails", async () => {
       mockGet.mockRejectedValue(new Error("fetch failed"))
       const result = await sdk.health.check()
       expect(result.status).toBe("error")

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -421,15 +421,16 @@ describe("OpenSeaCLI", () => {
       expect(mockGet).toHaveBeenCalledWith("/api/v2/collections", {
         limit: 1,
       })
-      expect(mockGet).toHaveBeenCalledWith("/api/v2/listings/collection/boredapeyachtclub/all", {
-        limit: 1,
-      })
+      expect(mockGet).toHaveBeenCalledWith(
+        "/api/v2/listings/collection/boredapeyachtclub/all",
+        {
+          limit: 1,
+        },
+      )
       expect(result.status).toBe("ok")
       expect(result.authenticated).toBe(true)
       expect(result.key_prefix).toBe("test...")
-      expect(result.message).toBe(
-        "Connectivity and authentication are working",
-      )
+      expect(result.message).toBe("Connectivity and authentication are working")
     })
 
     it("check returns error when connectivity fails", async () => {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -485,6 +485,16 @@ describe("OpenSeaCLI", () => {
       expect(result.message).toContain("could not be verified")
     })
 
+    it("check returns error with rate_limited on 429", async () => {
+      mockGet.mockRejectedValue(
+        new OpenSeaAPIError(429, "Too Many Requests", "/api/v2/collections"),
+      )
+      const result = await sdk.health.check()
+      expect(result.status).toBe("error")
+      expect(result.rate_limited).toBe(true)
+      expect(result.message).toContain("Rate limited")
+    })
+
     it("check returns error when network fails", async () => {
       mockGet.mockRejectedValue(new Error("fetch failed"))
       const result = await sdk.health.check()


### PR DESCRIPTION
# feat: add `opensea health` diagnostic command (DIS-144)

## Summary

Adds a new `opensea health` command that validates API connectivity **and** authentication before running expensive operations. Performs a two-step check:

1. **Connectivity**: `GET /api/v2/collections?limit=1` (public endpoint — succeeds regardless of key validity)
2. **Authentication**: `GET /api/v2/listings/collection/boredapeyachtclub/all?limit=1` (requires valid API key)

Outputs structured JSON:

```json
{ "status": "ok", "key_prefix": "8d02...", "authenticated": true, "rate_limited": false, "message": "Connectivity and authentication are working" }
```

Exit codes: `0` = success, `1` = error (auth failure, API error, network error), `3` = rate limited (429).

If step 1 succeeds but step 2 fails with a non-auth error (e.g., 500), the command returns `"status": "ok"` with `"authenticated": false` and a message indicating auth could not be verified.

**Changes:**
- `src/client.ts`: Added `getApiKeyPrefix()` — returns first 4 chars of API key, or `"***"` for keys shorter than 8 chars to prevent leaking short keys
- `src/health.ts`: New shared `checkHealth(client)` function with two-step connectivity + auth validation (used by both CLI and SDK)
- `src/commands/health.ts`: Thin CLI wrapper — delegates to `checkHealth`, formats output, exits with code 1 or 3
- `src/sdk.ts`: Added `HealthAPI` class with `check()` method for programmatic consumers, delegates to `checkHealth`
- `src/types/index.ts`: Added `HealthResult` interface with `status`, `key_prefix`, `authenticated`, `rate_limited`, `message`
- Registered command in barrel export (`src/commands/index.ts`), CLI (`src/cli.ts`), and package entry (`src/index.ts`)
- `test/mocks.ts`: Added `getApiKeyPrefix` to `MockClient` type
- Full test coverage across command, SDK, and client layers (167 tests passing)

**Confidence: 🟡 Medium-High** — All 167 tests pass, lint and type-check clean. Not verified against the live OpenSea API.

Resolves [DIS-144](https://linear.app/opensea/issue/DIS-144/opensea-cli-add-opensea-health-diagnostic-command)

## Review & Testing Checklist for Human

- [ ] **E2E with valid key**: Run `npx . health --api-key <valid_key>` — should return `"status": "ok"`, `"authenticated": true`
- [ ] **E2E with invalid key**: Run `npx . health --api-key invalidkey123` — should return `"status": "error"`, `"authenticated": false`, exit code 1
- [ ] **Hardcoded collection slug**: The auth check uses `boredapeyachtclub` — verify this collection still exists and requires auth. If it's ever removed/renamed, the health check's auth step will break. Consider whether this should be configurable or use a different endpoint.
- [ ] **SDK path**: Instantiate `OpenSeaCLI` and call `sdk.health.check()` to verify the shared `checkHealth` function works through the SDK

### Notes
- Link to Devin Session: https://app.devin.ai/sessions/c4ffbaa243ef4109b1260fb92771dc71
- Requested by: @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
