### PR TITLE
feat: add exit code 3 for rate limiting (DIS-146)

### DIFF
--- a/.agents/rules.md
+++ b/.agents/rules.md
@@ -160,9 +160,9 @@ Key aspects:
 ### Error Handling
 
 - API errors are wrapped in `OpenSeaAPIError` (includes status code, response body, path).
-- CLI catches `OpenSeaAPIError` and outputs structured JSON to stderr, then exits with code 1.
+- CLI catches `OpenSeaAPIError` and outputs structured JSON to stderr, then exits with code 1 (or code 3 for rate limiting).
 - Authentication errors (missing API key) exit with code 2.
-- Exit codes: 0 = success, 1 = API error, 2 = auth error.
+- Exit codes: 0 = success, 1 = API error, 2 = auth error, 3 = rate limited (HTTP 429).
 
 ## Design Rules
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ console.log(formatToon(data))
 - `0` - Success
 - `1` - API error
 - `2` - Authentication error
+- `3` - Rate limited (HTTP 429)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ console.log(formatToon(data))
 ## Exit Codes
 
 - `0` - Success
-- `1` - API error
+- `1` - API error (non-429)
 - `2` - Authentication error
 - `3` - Rate limited (HTTP 429)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,10 @@ import {
 import type { OutputFormat } from "./output.js"
 import { parseIntOption } from "./parse.js"
 
+const EXIT_API_ERROR = 1
+const EXIT_AUTH_ERROR = 2
+const EXIT_RATE_LIMITED = 3
+
 const BANNER = `
    ____                   _____
   / __ \\                 / ____|
@@ -53,7 +57,7 @@ function getClient(): OpenSeaClient {
     console.error(
       "Error: API key required. Use --api-key or set OPENSEA_API_KEY environment variable.",
     )
-    process.exit(2)
+    process.exit(EXIT_AUTH_ERROR)
   }
 
   return new OpenSeaClient({
@@ -100,7 +104,7 @@ async function main() {
           2,
         ),
       )
-      process.exit(isRateLimited ? 3 : 1)
+      process.exit(isRateLimited ? EXIT_RATE_LIMITED : EXIT_API_ERROR)
     }
     const label =
       error instanceof TypeError ? "Network Error" : (error as Error).name
@@ -114,7 +118,7 @@ async function main() {
         2,
       ),
     )
-    process.exit(1)
+    process.exit(EXIT_API_ERROR)
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,10 +87,11 @@ async function main() {
     await program.parseAsync(process.argv)
   } catch (error) {
     if (error instanceof OpenSeaAPIError) {
+      const isRateLimited = error.statusCode === 429
       console.error(
         JSON.stringify(
           {
-            error: "API Error",
+            error: isRateLimited ? "Rate Limited" : "API Error",
             status: error.statusCode,
             path: error.path,
             message: error.responseBody,
@@ -99,7 +100,7 @@ async function main() {
           2,
         ),
       )
-      process.exit(1)
+      process.exit(isRateLimited ? 3 : 1)
     }
     const label =
       error instanceof TypeError ? "Network Error" : (error as Error).name

--- a/test/cli-api-error.test.ts
+++ b/test/cli-api-error.test.ts
@@ -1,0 +1,41 @@
+import { Command } from "commander"
+import { afterAll, expect, it, vi } from "vitest"
+import { OpenSeaAPIError } from "../src/client.js"
+
+vi.mock("../src/commands/index.js", () => ({
+  accountsCommand: () => new Command("accounts"),
+  collectionsCommand: () => new Command("collections"),
+  eventsCommand: () => new Command("events"),
+  listingsCommand: () => new Command("listings"),
+  nftsCommand: () => new Command("nfts"),
+  offersCommand: () => new Command("offers"),
+  searchCommand: () => new Command("search"),
+  swapsCommand: () => new Command("swaps"),
+  tokensCommand: () => new Command("tokens"),
+}))
+
+const exitSpy = vi
+  .spyOn(process, "exit")
+  .mockImplementation(() => undefined as never)
+const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+vi.spyOn(Command.prototype, "parseAsync").mockRejectedValue(
+  new OpenSeaAPIError(404, "Not Found", "/api/v2/missing"),
+)
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
+
+it("exits with code 1 and 'API Error' label on non-429 API error", async () => {
+  await import("../src/cli.js")
+  await vi.waitFor(() => {
+    expect(exitSpy).toHaveBeenCalled()
+  })
+
+  expect(exitSpy).toHaveBeenCalledWith(1)
+  const output = stderrSpy.mock.calls[0][0] as string
+  const parsed = JSON.parse(output)
+  expect(parsed.error).toBe("API Error")
+  expect(parsed.status).toBe(404)
+})

--- a/test/cli-network-error.test.ts
+++ b/test/cli-network-error.test.ts
@@ -1,0 +1,39 @@
+import { Command } from "commander"
+import { afterAll, expect, it, vi } from "vitest"
+
+vi.mock("../src/commands/index.js", () => ({
+  accountsCommand: () => new Command("accounts"),
+  collectionsCommand: () => new Command("collections"),
+  eventsCommand: () => new Command("events"),
+  listingsCommand: () => new Command("listings"),
+  nftsCommand: () => new Command("nfts"),
+  offersCommand: () => new Command("offers"),
+  searchCommand: () => new Command("search"),
+  swapsCommand: () => new Command("swaps"),
+  tokensCommand: () => new Command("tokens"),
+}))
+
+const exitSpy = vi
+  .spyOn(process, "exit")
+  .mockImplementation(() => undefined as never)
+const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+vi.spyOn(Command.prototype, "parseAsync").mockRejectedValue(
+  new TypeError("fetch failed"),
+)
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
+
+it("exits with code 1 on non-API errors", async () => {
+  await import("../src/cli.js")
+  await vi.waitFor(() => {
+    expect(exitSpy).toHaveBeenCalled()
+  })
+
+  expect(exitSpy).toHaveBeenCalledWith(1)
+  const output = stderrSpy.mock.calls[0][0] as string
+  const parsed = JSON.parse(output)
+  expect(parsed.error).toBe("Network Error")
+})

--- a/test/cli-rate-limit.test.ts
+++ b/test/cli-rate-limit.test.ts
@@ -1,0 +1,43 @@
+import { Command } from "commander"
+import { afterAll, expect, it, vi } from "vitest"
+import { OpenSeaAPIError } from "../src/client.js"
+
+vi.mock("../src/commands/index.js", () => ({
+  accountsCommand: () => new Command("accounts"),
+  collectionsCommand: () => new Command("collections"),
+  eventsCommand: () => new Command("events"),
+  listingsCommand: () => new Command("listings"),
+  nftsCommand: () => new Command("nfts"),
+  offersCommand: () => new Command("offers"),
+  searchCommand: () => new Command("search"),
+  swapsCommand: () => new Command("swaps"),
+  tokensCommand: () => new Command("tokens"),
+}))
+
+const exitSpy = vi
+  .spyOn(process, "exit")
+  .mockImplementation(() => undefined as never)
+const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+vi.spyOn(Command.prototype, "parseAsync").mockRejectedValue(
+  new OpenSeaAPIError(429, "Rate limit exceeded", "/api/v2/test"),
+)
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
+
+it("exits with code 3 and 'Rate Limited' label on 429 error", async () => {
+  await import("../src/cli.js")
+  await vi.waitFor(() => {
+    expect(exitSpy).toHaveBeenCalled()
+  })
+
+  expect(exitSpy).toHaveBeenCalledWith(3)
+  const output = stderrSpy.mock.calls[0][0] as string
+  const parsed = JSON.parse(output)
+  expect(parsed.error).toBe("Rate Limited")
+  expect(parsed.status).toBe(429)
+  expect(parsed.path).toBe("/api/v2/test")
+  expect(parsed.message).toBe("Rate limit exceeded")
+})


### PR DESCRIPTION
# feat: add dedicated exit code 3 for rate limiting (DIS-146)

## Summary

When the OpenSea API returns HTTP 429, the CLI now exits with code **3** and labels the error as `"Rate Limited"` instead of the generic `"API Error"`. Previously, 429s were indistinguishable from other API errors (both exited with code 1), making it impossible for agents to programmatically detect rate limits and implement wait-and-retry.

**Exit codes after this change:** `0` success · `1` API error (non-429) · `2` auth error · `3` rate limited

**Files changed:**
- `src/cli.ts` — conditional check on `statusCode === 429` in the error handler; all exit codes use named constants (`EXIT_API_ERROR`, `EXIT_AUTH_ERROR`, `EXIT_RATE_LIMITED`)
- `README.md` / `.agents/rules.md` — updated exit code documentation
- 3 new test files covering the 429, non-429 API error, and network error exit paths

### Updates since last revision

Addressed reviewer feedback from @ckorhonen:
1. Extracted exit code constants — `EXIT_API_ERROR = 1`, `EXIT_AUTH_ERROR = 2`, `EXIT_RATE_LIMITED = 3` — replacing all magic numbers across the three `process.exit()` call sites
2. Clarified README exit code `1` as `API error (non-429)` to make the 429/non-429 split explicit

## Review & Testing Checklist for Human

- [ ] Verify the `isRateLimited` conditional in `src/cli.ts` correctly branches on `statusCode === 429` only — no other 4xx codes should trigger exit code 3
- [ ] **Manual test**: build the CLI, hit a rate-limited endpoint (or mock one), and confirm stderr output shows `"error": "Rate Limited"` with exit code 3
- [ ] If PR #35 (health command) merges alongside this, check that a rate-limited health check also uses exit code 3 — currently the health command catches errors internally and always exits 1

### Notes
- Confidence: 🟢 HIGH — small logic change with clear semantics; all 154 tests pass
- Test files are split across 3 files because `cli.ts` executes `main()` at import time, requiring separate module scopes per error scenario
- Linear ticket: [DIS-146](https://linear.app/opensea/issue/DIS-146/opensea-cli-add-dedicated-exit-code-3-for-rate-limiting)
- [Devin session](https://app.devin.ai/sessions/1f04c3d47a6146379cf6a69c1de7f7c1)
- Requested by: @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
