### PR TITLE
feat: add retry with exponential backoff in client.ts (DIS-143)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,8 @@ program
     "Comma-separated list of fields to include in output",
   )
   .option("--max-lines <lines>", "Truncate output after N lines")
+  .option("--max-retries <n>", "Max retries on 429/5xx (0 to disable)", "3")
+  .option("--no-retry", "Disable request retries")
 
 function getClient(): OpenSeaClient {
   const opts = program.opts<{
@@ -56,6 +58,8 @@ function getClient(): OpenSeaClient {
     baseUrl?: string
     timeout: string
     verbose?: boolean
+    maxRetries: string
+    retry: boolean
   }>()
 
   const apiKey = opts.apiKey ?? process.env.OPENSEA_API_KEY
@@ -66,12 +70,17 @@ function getClient(): OpenSeaClient {
     process.exit(EXIT_AUTH_ERROR)
   }
 
+  const maxRetries = opts.retry
+    ? parseIntOption(opts.maxRetries, "--max-retries")
+    : 0
+
   return new OpenSeaClient({
     apiKey,
     chain: opts.chain,
     baseUrl: opts.baseUrl,
     timeout: parseIntOption(opts.timeout, "--timeout"),
     verbose: opts.verbose,
+    maxRetries,
   })
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,25 @@ declare const __VERSION__: string
 const DEFAULT_BASE_URL = "https://api.opensea.io"
 const DEFAULT_TIMEOUT_MS = 30_000
 const USER_AGENT = `opensea-cli/${__VERSION__}`
+const DEFAULT_MAX_RETRIES = 3
+const DEFAULT_RETRY_BASE_DELAY_MS = 1_000
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500
+}
+
+function parseRetryAfter(header: string | null): number | undefined {
+  if (!header) return undefined
+  const seconds = Number(header)
+  if (!Number.isNaN(seconds)) return seconds * 1000
+  const date = Date.parse(header)
+  if (!Number.isNaN(date)) return Math.max(0, date - Date.now())
+  return undefined
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
 
 export class OpenSeaClient {
   private apiKey: string
@@ -12,6 +31,8 @@ export class OpenSeaClient {
   private defaultChain: string
   private timeoutMs: number
   private verbose: boolean
+  private maxRetries: number
+  private retryBaseDelay: number
 
   constructor(config: OpenSeaClientConfig) {
     this.apiKey = config.apiKey
@@ -19,6 +40,8 @@ export class OpenSeaClient {
     this.defaultChain = config.chain ?? "ethereum"
     this.timeoutMs = config.timeout ?? DEFAULT_TIMEOUT_MS
     this.verbose = config.verbose ?? false
+    this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES
+    this.retryBaseDelay = config.retryBaseDelay ?? DEFAULT_RETRY_BASE_DELAY_MS
   }
 
   private get defaultHeaders(): Record<string, string> {
@@ -44,20 +67,15 @@ export class OpenSeaClient {
       console.error(`[verbose] GET ${url.toString()}`)
     }
 
-    const response = await fetch(url.toString(), {
-      method: "GET",
-      headers: this.defaultHeaders,
-      signal: AbortSignal.timeout(this.timeoutMs),
-    })
-
-    if (this.verbose) {
-      console.error(`[verbose] ${response.status} ${response.statusText}`)
-    }
-
-    if (!response.ok) {
-      const body = await response.text()
-      throw new OpenSeaAPIError(response.status, body, path)
-    }
+    const response = await this.fetchWithRetry(
+      url.toString(),
+      {
+        method: "GET",
+        headers: this.defaultHeaders,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      },
+      path,
+    )
 
     return response.json() as Promise<T>
   }
@@ -87,21 +105,16 @@ export class OpenSeaClient {
       console.error(`[verbose] POST ${url.toString()}`)
     }
 
-    const response = await fetch(url.toString(), {
-      method: "POST",
-      headers,
-      body: body ? JSON.stringify(body) : undefined,
-      signal: AbortSignal.timeout(this.timeoutMs),
-    })
-
-    if (this.verbose) {
-      console.error(`[verbose] ${response.status} ${response.statusText}`)
-    }
-
-    if (!response.ok) {
-      const text = await response.text()
-      throw new OpenSeaAPIError(response.status, text, path)
-    }
+    const response = await this.fetchWithRetry(
+      url.toString(),
+      {
+        method: "POST",
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      },
+      path,
+    )
 
     return response.json() as Promise<T>
   }
@@ -113,6 +126,48 @@ export class OpenSeaClient {
   getApiKeyPrefix(): string {
     if (this.apiKey.length < 8) return "***"
     return `${this.apiKey.slice(0, 4)}...`
+  }
+
+  private async fetchWithRetry(
+    url: string,
+    init: RequestInit,
+    path: string,
+  ): Promise<Response> {
+    for (let attempt = 0; ; attempt++) {
+      const response = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+
+      if (this.verbose) {
+        console.error(`[verbose] ${response.status} ${response.statusText}`)
+      }
+
+      if (response.ok) {
+        return response
+      }
+
+      if (attempt < this.maxRetries && isRetryableStatus(response.status)) {
+        const retryAfterMs = parseRetryAfter(
+          response.headers.get("Retry-After"),
+        )
+        const backoffMs = this.retryBaseDelay * 2 ** attempt
+        const jitterMs = Math.random() * this.retryBaseDelay
+        const delayMs = Math.max(retryAfterMs ?? 0, backoffMs) + jitterMs
+
+        if (this.verbose) {
+          console.error(
+            `[verbose] Retry ${attempt + 1}/${this.maxRetries} after ${Math.round(delayMs)}ms (status ${response.status})`,
+          )
+        }
+
+        await sleep(delayMs)
+        continue
+      }
+
+      const text = await response.text()
+      throw new OpenSeaAPIError(response.status, text, path)
+    }
   }
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,11 +5,12 @@ declare const __VERSION__: string
 const DEFAULT_BASE_URL = "https://api.opensea.io"
 const DEFAULT_TIMEOUT_MS = 30_000
 const USER_AGENT = `opensea-cli/${__VERSION__}`
-const DEFAULT_MAX_RETRIES = 3
+const DEFAULT_MAX_RETRIES = 0
 const DEFAULT_RETRY_BASE_DELAY_MS = 1_000
 
-function isRetryableStatus(status: number): boolean {
-  return status === 429 || status >= 500
+function isRetryableStatus(status: number, method: string): boolean {
+  if (status === 429) return true
+  return status >= 500 && method === "GET"
 }
 
 function parseRetryAfter(header: string | null): number | undefined {
@@ -145,7 +146,11 @@ export class OpenSeaClient {
         return response
       }
 
-      if (attempt < this.maxRetries && isRetryableStatus(response.status)) {
+      const method = init.method ?? "GET"
+      if (
+        attempt < this.maxRetries &&
+        isRetryableStatus(response.status, method)
+      ) {
         const retryAfterMs = parseRetryAfter(
           response.headers.get("Retry-After"),
         )
@@ -159,7 +164,11 @@ export class OpenSeaClient {
           )
         }
 
-        await response.body?.cancel()
+        try {
+          await response.body?.cancel()
+        } catch {
+          // Stream may already be disturbed
+        }
         await sleep(delayMs)
         continue
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -72,7 +72,6 @@ export class OpenSeaClient {
       {
         method: "GET",
         headers: this.defaultHeaders,
-        signal: AbortSignal.timeout(this.timeoutMs),
       },
       path,
     )
@@ -111,7 +110,6 @@ export class OpenSeaClient {
         method: "POST",
         headers,
         body: body ? JSON.stringify(body) : undefined,
-        signal: AbortSignal.timeout(this.timeoutMs),
       },
       path,
     )

--- a/src/client.ts
+++ b/src/client.ts
@@ -161,6 +161,7 @@ export class OpenSeaClient {
           )
         }
 
+        await response.body?.cancel()
         await sleep(delayMs)
         continue
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,8 @@ export interface OpenSeaClientConfig {
   chain?: string
   timeout?: number
   verbose?: boolean
+  maxRetries?: number
+  retryBaseDelay?: number
 }
 
 export interface CommandOptions {

--- a/test/cli-api-error.test.ts
+++ b/test/cli-api-error.test.ts
@@ -12,6 +12,7 @@ vi.mock("../src/commands/index.js", () => ({
   searchCommand: () => new Command("search"),
   swapsCommand: () => new Command("swaps"),
   tokensCommand: () => new Command("tokens"),
+  healthCommand: () => new Command("health"),
 }))
 
 const exitSpy = vi

--- a/test/cli-network-error.test.ts
+++ b/test/cli-network-error.test.ts
@@ -11,6 +11,7 @@ vi.mock("../src/commands/index.js", () => ({
   searchCommand: () => new Command("search"),
   swapsCommand: () => new Command("swaps"),
   tokensCommand: () => new Command("tokens"),
+  healthCommand: () => new Command("health"),
 }))
 
 const exitSpy = vi

--- a/test/cli-rate-limit.test.ts
+++ b/test/cli-rate-limit.test.ts
@@ -12,6 +12,7 @@ vi.mock("../src/commands/index.js", () => ({
   searchCommand: () => new Command("search"),
   swapsCommand: () => new Command("swaps"),
   tokensCommand: () => new Command("tokens"),
+  healthCommand: () => new Command("health"),
 }))
 
 const exitSpy = vi

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -6,7 +6,7 @@ describe("OpenSeaClient", () => {
   let client: OpenSeaClient
 
   beforeEach(() => {
-    client = new OpenSeaClient({ apiKey: "test-key" })
+    client = new OpenSeaClient({ apiKey: "test-key", maxRetries: 0 })
   })
 
   afterEach(() => {
@@ -140,6 +140,198 @@ describe("OpenSeaClient", () => {
       mockFetchTextResponse("Server Error", 500)
 
       await expect(client.post("/api/v2/fail")).rejects.toThrow(OpenSeaAPIError)
+    })
+  })
+
+  describe("retry", () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it("retries on 429 and succeeds", async () => {
+      const retryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 3,
+        retryBaseDelay: 100,
+      })
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response("Rate limited", { status: 429 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        )
+
+      const promise = retryClient.get("/api/v2/test")
+      await vi.advanceTimersByTimeAsync(10_000)
+      const result = await promise
+
+      expect(result).toEqual({ ok: true })
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it("retries on 500 and succeeds", async () => {
+      const retryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 3,
+        retryBaseDelay: 100,
+      })
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        )
+
+      const promise = retryClient.get("/api/v2/test")
+      await vi.advanceTimersByTimeAsync(10_000)
+      const result = await promise
+
+      expect(result).toEqual({ ok: true })
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it("throws after exhausting all retries", async () => {
+      const retryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 2,
+        retryBaseDelay: 100,
+      })
+      vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.resolve(new Response("Rate limited", { status: 429 })),
+      )
+
+      const promise = retryClient.get("/api/v2/test").catch((e: unknown) => e)
+      await vi.advanceTimersByTimeAsync(60_000)
+      const error = await promise
+
+      expect(error).toBeInstanceOf(OpenSeaAPIError)
+      expect(fetch).toHaveBeenCalledTimes(3)
+    })
+
+    it("does not retry on 404", async () => {
+      const retryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 3,
+        retryBaseDelay: 100,
+      })
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("Not Found", { status: 404 }),
+      )
+
+      await expect(retryClient.get("/api/v2/test")).rejects.toThrow(
+        OpenSeaAPIError,
+      )
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not retry when maxRetries is 0", async () => {
+      const noRetryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 0,
+      })
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("Rate limited", { status: 429 }),
+      )
+
+      await expect(noRetryClient.get("/api/v2/test")).rejects.toThrow(
+        OpenSeaAPIError,
+      )
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it("respects Retry-After header (seconds)", async () => {
+      const retryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 1,
+        retryBaseDelay: 100,
+      })
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          new Response("Rate limited", {
+            status: 429,
+            headers: { "Retry-After": "5" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        )
+
+      const promise = retryClient.get("/api/v2/test")
+      // Advance past the 5s Retry-After + jitter
+      await vi.advanceTimersByTimeAsync(10_000)
+      const result = await promise
+
+      expect(result).toEqual({ ok: true })
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it("retries post requests", async () => {
+      const retryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 3,
+        retryBaseDelay: 100,
+      })
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response("Server Error", { status: 503 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ status: "ok" }), {
+            status: 200,
+          }),
+        )
+
+      const promise = retryClient.post("/api/v2/refresh")
+      await vi.advanceTimersByTimeAsync(10_000)
+      const result = await promise
+
+      expect(result).toEqual({ status: "ok" })
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it("logs retries when verbose is enabled", async () => {
+      const verboseRetryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 3,
+        retryBaseDelay: 100,
+        verbose: true,
+      })
+      const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response("Rate limited", { status: 429 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        )
+
+      const promise = verboseRetryClient.get("/api/v2/test")
+      await vi.advanceTimersByTimeAsync(10_000)
+      await promise
+
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /\[verbose\] Retry 1\/3 after \d+ms \(status 429\)/,
+        ),
+      )
+    })
+
+    it("does not log retries when verbose is disabled", async () => {
+      const retryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 3,
+        retryBaseDelay: 100,
+      })
+      const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response("Rate limited", { status: 429 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        )
+
+      const promise = retryClient.get("/api/v2/test")
+      await vi.advanceTimersByTimeAsync(10_000)
+      await promise
+
+      expect(stderrSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -267,14 +267,14 @@ describe("OpenSeaClient", () => {
       expect(fetch).toHaveBeenCalledTimes(2)
     })
 
-    it("retries post requests", async () => {
+    it("retries post requests on 429", async () => {
       const retryClient = new OpenSeaClient({
         apiKey: "test-key",
         maxRetries: 3,
         retryBaseDelay: 100,
       })
       vi.spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(new Response("Server Error", { status: 503 }))
+        .mockResolvedValueOnce(new Response("Rate limited", { status: 429 }))
         .mockResolvedValueOnce(
           new Response(JSON.stringify({ status: "ok" }), {
             status: 200,
@@ -287,6 +287,22 @@ describe("OpenSeaClient", () => {
 
       expect(result).toEqual({ status: "ok" })
       expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it("does not retry post requests on 5xx", async () => {
+      const retryClient = new OpenSeaClient({
+        apiKey: "test-key",
+        maxRetries: 3,
+        retryBaseDelay: 100,
+      })
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("Server Error", { status: 503 }),
+      )
+
+      await expect(retryClient.post("/api/v2/refresh")).rejects.toThrow(
+        OpenSeaAPIError,
+      )
+      expect(fetch).toHaveBeenCalledTimes(1)
     })
 
     it("logs retries when verbose is enabled", async () => {


### PR DESCRIPTION
# feat: add retry with exponential backoff in client.ts (DIS-143)

## Summary

Adds automatic retry with exponential backoff to `OpenSeaClient` for transient failures. Both `get()` and `post()` now delegate to a shared `fetchWithRetry()` private method that handles the retry loop.

**Config additions** (`OpenSeaClientConfig`):
- `maxRetries` (default 0) — number of retries before giving up. SDK defaults to 0 (no retries) for backwards compatibility; CLI defaults to 3 via `--max-retries`.
- `retryBaseDelay` (default 1000ms) — base delay for exponential backoff

**CLI flags**:
- `--max-retries <n>` — override max retries (default "3")
- `--no-retry` — disable retries entirely (sets maxRetries to 0)

**Retry behavior**:
- GET requests: retries on 429 (rate limit) and 5xx (server error)
- POST requests: retries on 429 only (not 5xx, since POST is not idempotent)
- Other 4xx errors throw immediately regardless of method
- Delay = max(Retry-After header, baseDelay × 2^attempt) + random jitter
- Retry-After parsed as seconds or HTTP-date
- Each retry attempt gets a fresh `AbortSignal.timeout` so the per-request timeout applies independently per attempt
- Response bodies are safely cancelled on retryable errors to release sockets back to the connection pool
- Retry attempts logged to stderr when `--verbose` is enabled

## Updates since last revision

- Resolved merge conflicts with `main` which introduced `healthCommand` (DIS-144), `--fields`/`--max-lines` options (DIS-145), `getApiKeyPrefix()`, and User-Agent header (DIS-41).
- Updated CLI error test mocks (`cli-api-error`, `cli-network-error`, `cli-rate-limit`) to include the new `healthCommand` export.
- `get()` and `post()` now use `this.defaultHeaders` (which includes User-Agent) instead of inline header objects.

## Review & Testing Checklist for Human

- [ ] **POST idempotency**: Verify that POST requests are only retried on 429, never on 5xx. The `isRetryableStatus(status, method)` function gates this — confirm via the test "does not retry post requests on 5xx".
- [ ] **SDK backwards compatibility**: `maxRetries` defaults to 0 in `client.ts`, so `new OpenSeaClient({apiKey})` has no retries (same as before). The CLI passes `maxRetries: 3` explicitly. Confirm no SDK consumers are broken.
- [ ] **`Retry-After` HTTP-date parsing**: `parseRetryAfter` uses `Date.parse()` for HTTP-date format. Only the numeric-seconds path is unit tested. Verify this is acceptable or add a test for the date path.
- [ ] **Manual E2E test**: Run `opensea collections get <slug> --verbose` against the live API to confirm retry logging and normal request flow. Also verify `--no-retry` disables retries and that `--max-retries 0` behaves equivalently.

### Notes
- Ticket: [DIS-143](https://linear.app/opensea/issue/DIS-143/opensea-cli-add-retry-with-exponential-backoff-in-clientts)
- Link to Devin session: https://app.devin.ai/sessions/96c90aad7f9d476fba82799fd15ef871
- Requested by: @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
