### PR TITLE
feat: add --fields and --max-lines global CLI options (DIS-145)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import {
   swapsCommand,
   tokensCommand,
 } from "./commands/index.js"
-import type { OutputFormat } from "./output.js"
+import { type OutputFormat, setOutputOptions } from "./output.js"
 import { parseIntOption } from "./parse.js"
 
 const BANNER = `
@@ -38,6 +38,11 @@ program
   .option("--base-url <url>", "API base URL")
   .option("--timeout <ms>", "Request timeout in milliseconds", "30000")
   .option("--verbose", "Log request and response info to stderr")
+  .option(
+    "--fields <fields>",
+    "Comma-separated list of fields to include in output",
+  )
+  .option("--max-lines <lines>", "Truncate output after N lines")
 
 function getClient(): OpenSeaClient {
   const opts = program.opts<{
@@ -71,6 +76,19 @@ function getFormat(): OutputFormat {
   if (opts.format === "toon") return "toon"
   return "json"
 }
+
+program.hook("preAction", () => {
+  const opts = program.opts<{
+    fields?: string
+    maxLines?: string
+  }>()
+  setOutputOptions({
+    fields: opts.fields?.split(",").map(f => f.trim()),
+    maxLines: opts.maxLines
+      ? parseIntOption(opts.maxLines, "--max-lines")
+      : undefined,
+  })
+})
 
 program.addCommand(collectionsCommand(getClient, getFormat))
 program.addCommand(nftsCommand(getClient, getFormat))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,11 +82,17 @@ program.hook("preAction", () => {
     fields?: string
     maxLines?: string
   }>()
+  let maxLines: number | undefined
+  if (opts.maxLines) {
+    maxLines = parseIntOption(opts.maxLines, "--max-lines")
+    if (maxLines < 1) {
+      console.error("Error: --max-lines must be >= 1")
+      process.exit(2)
+    }
+  }
   setOutputOptions({
     fields: opts.fields?.split(",").map(f => f.trim()),
-    maxLines: opts.maxLines
-      ? parseIntOption(opts.maxLines, "--max-lines")
-      : undefined,
+    maxLines,
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { OpenSeaAPIError, OpenSeaClient } from "./client.js"
-export type { OutputFormat, OutputOptions } from "./output.js"
-export { formatOutput, setOutputOptions } from "./output.js"
+export type { OutputFormat } from "./output.js"
+export { formatOutput } from "./output.js"
 export { OpenSeaCLI } from "./sdk.js"
 export { formatToon } from "./toon.js"
 export type * from "./types/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { OpenSeaAPIError, OpenSeaClient } from "./client.js"
-export type { OutputFormat } from "./output.js"
-export { formatOutput } from "./output.js"
+export type { OutputFormat, OutputOptions } from "./output.js"
+export { formatOutput, setOutputOptions } from "./output.js"
 export { OpenSeaCLI } from "./sdk.js"
 export { formatToon } from "./toon.js"
 export type * from "./types/index.js"

--- a/src/output.ts
+++ b/src/output.ts
@@ -98,24 +98,7 @@ function filterFields(data: unknown, fields: string[]): unknown {
     return data.map(item => filterFields(item, fields))
   }
   if (data && typeof data === "object") {
-    const obj = data as Record<string, unknown>
-    const keys = Object.keys(obj)
-    const hasMatchingKey = fields.some(f => f in obj)
-    if (hasMatchingKey) {
-      return pickFields(obj, fields)
-    }
-    const result: Record<string, unknown> = {}
-    for (const key of keys) {
-      const value = obj[key]
-      result[key] = Array.isArray(value)
-        ? value.map(item =>
-            item && typeof item === "object"
-              ? pickFields(item as Record<string, unknown>, fields)
-              : item,
-          )
-        : value
-    }
-    return result
+    return pickFields(data as Record<string, unknown>, fields)
   }
   return data
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -27,7 +27,7 @@ export function formatOutput(data: unknown, format: OutputFormat): string {
     result = JSON.stringify(processed, null, 2)
   }
 
-  if (_outputOptions.maxLines) {
+  if (_outputOptions.maxLines != null) {
     result = truncateOutput(result, _outputOptions.maxLines)
   }
 
@@ -99,21 +99,23 @@ function filterFields(data: unknown, fields: string[]): unknown {
   }
   if (data && typeof data === "object") {
     const obj = data as Record<string, unknown>
-    const arrayKeys = Object.keys(obj).filter(k => Array.isArray(obj[k]))
-    if (arrayKeys.length > 0) {
-      const result: Record<string, unknown> = {}
-      for (const [key, value] of Object.entries(obj)) {
-        result[key] = Array.isArray(value)
-          ? value.map(item =>
-              item && typeof item === "object"
-                ? pickFields(item as Record<string, unknown>, fields)
-                : item,
-            )
-          : value
-      }
-      return result
+    const keys = Object.keys(obj)
+    const hasMatchingKey = fields.some(f => f in obj)
+    if (hasMatchingKey) {
+      return pickFields(obj, fields)
     }
-    return pickFields(obj, fields)
+    const result: Record<string, unknown> = {}
+    for (const key of keys) {
+      const value = obj[key]
+      result[key] = Array.isArray(value)
+        ? value.map(item =>
+            item && typeof item === "object"
+              ? pickFields(item as Record<string, unknown>, fields)
+              : item,
+          )
+        : value
+    }
+    return result
   }
   return data
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -2,14 +2,36 @@ import { formatToon } from "./toon.js"
 
 export type OutputFormat = "json" | "table" | "toon"
 
+export interface OutputOptions {
+  fields?: string[]
+  maxLines?: number
+}
+
+let _outputOptions: OutputOptions = {}
+
+export function setOutputOptions(options: OutputOptions): void {
+  _outputOptions = options
+}
+
 export function formatOutput(data: unknown, format: OutputFormat): string {
+  const processed = _outputOptions.fields
+    ? filterFields(data, _outputOptions.fields)
+    : data
+
+  let result: string
   if (format === "table") {
-    return formatTable(data)
+    result = formatTable(processed)
+  } else if (format === "toon") {
+    result = formatToon(processed)
+  } else {
+    result = JSON.stringify(processed, null, 2)
   }
-  if (format === "toon") {
-    return formatToon(data)
+
+  if (_outputOptions.maxLines) {
+    result = truncateOutput(result, _outputOptions.maxLines)
   }
-  return JSON.stringify(data, null, 2)
+
+  return result
 }
 
 function formatTable(data: unknown): string {
@@ -56,4 +78,52 @@ function formatTable(data: unknown): string {
   }
 
   return String(data)
+}
+
+function pickFields(
+  obj: Record<string, unknown>,
+  fields: string[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const field of fields) {
+    if (field in obj) {
+      result[field] = obj[field]
+    }
+  }
+  return result
+}
+
+function filterFields(data: unknown, fields: string[]): unknown {
+  if (Array.isArray(data)) {
+    return data.map(item => filterFields(item, fields))
+  }
+  if (data && typeof data === "object") {
+    const obj = data as Record<string, unknown>
+    const arrayKeys = Object.keys(obj).filter(k => Array.isArray(obj[k]))
+    if (arrayKeys.length > 0) {
+      const result: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(obj)) {
+        result[key] = Array.isArray(value)
+          ? value.map(item =>
+              item && typeof item === "object"
+                ? pickFields(item as Record<string, unknown>, fields)
+                : item,
+            )
+          : value
+      }
+      return result
+    }
+    return pickFields(obj, fields)
+  }
+  return data
+}
+
+function truncateOutput(text: string, maxLines: number): string {
+  const lines = text.split("\n")
+  if (lines.length <= maxLines) return text
+  const omitted = lines.length - maxLines
+  return (
+    lines.slice(0, maxLines).join("\n") +
+    `\n... (${omitted} more line${omitted === 1 ? "" : "s"})`
+  )
 }

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -88,22 +88,15 @@ describe("formatOutput", () => {
       expect(result).toEqual({ name: "Cool NFT", collection: "cool-cats" })
     })
 
-    it("filters fields on items inside wrapped arrays", () => {
-      setOutputOptions({ fields: ["identifier", "name"] })
+    it("picks matching fields from wrapper objects", () => {
+      setOutputOptions({ fields: ["nfts", "next"] })
       const data = {
         nfts: [
-          {
-            identifier: "1",
-            name: "NFT #1",
-            image_url: "https://example.com/1.png",
-          },
-          {
-            identifier: "2",
-            name: "NFT #2",
-            image_url: "https://example.com/2.png",
-          },
+          { identifier: "1", name: "NFT #1" },
+          { identifier: "2", name: "NFT #2" },
         ],
         next: "cursor123",
+        extra: "dropped",
       }
       const result = JSON.parse(formatOutput(data, "json"))
       expect(result).toEqual({
@@ -200,27 +193,17 @@ describe("formatOutput", () => {
       expect(lines).toHaveLength(3)
       expect(lines[2]).toMatch(/\.\.\. \(\d+ more lines?\)/)
     })
-
-    it("handles max-lines 0 by truncating all lines", () => {
-      setOutputOptions({ maxLines: 0 })
-      const data = { a: 1 }
-      const result = formatOutput(data, "json")
-      expect(result).toContain("... (3 more lines)")
-    })
   })
 
   describe("--fields and --max-lines combined", () => {
     it("applies field filtering then truncation", () => {
       setOutputOptions({ fields: ["name"], maxLines: 3 })
-      const data = {
-        nfts: [
-          { name: "A", id: 1 },
-          { name: "B", id: 2 },
-          { name: "C", id: 3 },
-          { name: "D", id: 4 },
-        ],
-        next: "cursor",
-      }
+      const data = [
+        { name: "A", id: 1 },
+        { name: "B", id: 2 },
+        { name: "C", id: 3 },
+        { name: "D", id: 4 },
+      ]
       const result = formatOutput(data, "json")
       expect(result).not.toContain("id")
       const lines = result.split("\n")

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -132,6 +132,23 @@ describe("formatOutput", () => {
       expect(result).toEqual({ name: "test" })
     })
 
+    it("filters top-level fields on objects with array properties", () => {
+      setOutputOptions({ fields: ["name", "collection"] })
+      const data = {
+        name: "Cool Cats",
+        collection: "cool-cats",
+        description: "A cool collection",
+        contracts: [{ address: "0x1", chain: "ethereum" }],
+        editors: ["alice"],
+        fees: [{ fee: 250, recipient: "0x2", required: true }],
+      }
+      const result = JSON.parse(formatOutput(data, "json"))
+      expect(result).toEqual({
+        name: "Cool Cats",
+        collection: "cool-cats",
+      })
+    })
+
     it("returns primitives unchanged", () => {
       setOutputOptions({ fields: ["name"] })
       expect(formatOutput("hello", "json")).toBe('"hello"')
@@ -182,6 +199,13 @@ describe("formatOutput", () => {
       const lines = result.split("\n")
       expect(lines).toHaveLength(3)
       expect(lines[2]).toMatch(/\.\.\. \(\d+ more lines?\)/)
+    })
+
+    it("handles max-lines 0 by truncating all lines", () => {
+      setOutputOptions({ maxLines: 0 })
+      const data = { a: 1 }
+      const result = formatOutput(data, "json")
+      expect(result).toContain("... (3 more lines)")
     })
   })
 

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest"
-import { formatOutput } from "../src/output.js"
+import { afterEach, describe, expect, it } from "vitest"
+import { formatOutput, setOutputOptions } from "../src/output.js"
 
 describe("formatOutput", () => {
+  afterEach(() => {
+    setOutputOptions({})
+  })
+
   describe("json format", () => {
     it("formats data as pretty JSON", () => {
       const data = { name: "test", value: 42 }
@@ -68,6 +72,136 @@ describe("formatOutput", () => {
     it("formats primitive values as strings", () => {
       expect(formatOutput("hello", "table")).toBe("hello")
       expect(formatOutput(42, "table")).toBe("42")
+    })
+  })
+
+  describe("--fields option", () => {
+    it("filters top-level fields on a plain object", () => {
+      setOutputOptions({ fields: ["name", "collection"] })
+      const data = {
+        name: "Cool NFT",
+        collection: "cool-cats",
+        description: "A cool cat",
+        image_url: "https://example.com/img.png",
+      }
+      const result = JSON.parse(formatOutput(data, "json"))
+      expect(result).toEqual({ name: "Cool NFT", collection: "cool-cats" })
+    })
+
+    it("filters fields on items inside wrapped arrays", () => {
+      setOutputOptions({ fields: ["identifier", "name"] })
+      const data = {
+        nfts: [
+          {
+            identifier: "1",
+            name: "NFT #1",
+            image_url: "https://example.com/1.png",
+          },
+          {
+            identifier: "2",
+            name: "NFT #2",
+            image_url: "https://example.com/2.png",
+          },
+        ],
+        next: "cursor123",
+      }
+      const result = JSON.parse(formatOutput(data, "json"))
+      expect(result).toEqual({
+        nfts: [
+          { identifier: "1", name: "NFT #1" },
+          { identifier: "2", name: "NFT #2" },
+        ],
+        next: "cursor123",
+      })
+    })
+
+    it("filters fields on a bare array", () => {
+      setOutputOptions({ fields: ["name"] })
+      const data = [
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 25 },
+      ]
+      const result = JSON.parse(formatOutput(data, "json"))
+      expect(result).toEqual([{ name: "Alice" }, { name: "Bob" }])
+    })
+
+    it("ignores fields that do not exist", () => {
+      setOutputOptions({ fields: ["name", "nonexistent"] })
+      const data = { name: "test", value: 42 }
+      const result = JSON.parse(formatOutput(data, "json"))
+      expect(result).toEqual({ name: "test" })
+    })
+
+    it("returns primitives unchanged", () => {
+      setOutputOptions({ fields: ["name"] })
+      expect(formatOutput("hello", "json")).toBe('"hello"')
+    })
+
+    it("works with table format", () => {
+      setOutputOptions({ fields: ["name"] })
+      const data = [
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 25 },
+      ]
+      const result = formatOutput(data, "table")
+      expect(result).toContain("name")
+      expect(result).not.toContain("age")
+    })
+  })
+
+  describe("--max-lines option", () => {
+    it("truncates output exceeding max lines", () => {
+      setOutputOptions({ maxLines: 3 })
+      const data = { a: 1, b: 2, c: 3, d: 4, e: 5 }
+      const result = formatOutput(data, "json")
+      const lines = result.split("\n")
+      expect(lines).toHaveLength(4)
+      expect(lines[3]).toBe("... (4 more lines)")
+    })
+
+    it("does not truncate when output fits within max lines", () => {
+      setOutputOptions({ maxLines: 100 })
+      const data = { a: 1 }
+      const result = formatOutput(data, "json")
+      expect(result).not.toContain("...")
+      expect(result).toBe(JSON.stringify(data, null, 2))
+    })
+
+    it("uses singular 'line' for exactly one omitted line", () => {
+      setOutputOptions({ maxLines: 2 })
+      const data = { a: 1 }
+      const result = formatOutput(data, "json")
+      const lines = result.split("\n")
+      expect(lines[lines.length - 1]).toBe("... (1 more line)")
+    })
+
+    it("works with table format", () => {
+      setOutputOptions({ maxLines: 2 })
+      const data = [{ name: "Alice" }, { name: "Bob" }, { name: "Charlie" }]
+      const result = formatOutput(data, "table")
+      const lines = result.split("\n")
+      expect(lines).toHaveLength(3)
+      expect(lines[2]).toMatch(/\.\.\. \(\d+ more lines?\)/)
+    })
+  })
+
+  describe("--fields and --max-lines combined", () => {
+    it("applies field filtering then truncation", () => {
+      setOutputOptions({ fields: ["name"], maxLines: 3 })
+      const data = {
+        nfts: [
+          { name: "A", id: 1 },
+          { name: "B", id: 2 },
+          { name: "C", id: 3 },
+          { name: "D", id: 4 },
+        ],
+        next: "cursor",
+      }
+      const result = formatOutput(data, "json")
+      expect(result).not.toContain("id")
+      const lines = result.split("\n")
+      expect(lines).toHaveLength(4)
+      expect(lines[3]).toMatch(/\.\.\. \(\d+ more lines?\)/)
     })
   })
 })


### PR DESCRIPTION
# feat: add --fields and --max-lines global CLI options (DIS-145)

## Summary

Adds two global CLI options to control output size, motivated by agents piping CLI output through `python3 -m json.tool | head` which caused a 30-minute false-401 debugging incident.

- **`--fields <fields>`** — Comma-separated list of fields to include in output. Applies `pickFields` at the top level of the response object (or each item if the response is an array). For paginated wrapper responses like `{nfts: [...], next: "cursor"}`, users specify the wrapper keys they want (e.g. `--fields nfts,next`).
- **`--max-lines <lines>`** — Truncates formatted output after N lines, appending `... (N more lines)`. Must be >= 1.

Uses Commander's `preAction` hook with module-level state in `output.ts` so **zero command files were modified** — all 9 existing commands get both options for free.

## Updates since last revision

- **Removed wrapper-detection heuristic entirely** (per code review): `filterFields` now always applies `pickFields` at the top level. No more fragile heuristic that misidentified objects like `Collection` (with array properties) as paginated wrappers.
- **Removed `setOutputOptions`/`OutputOptions` from SDK barrel export** (per code review): These are CLI-internal concerns; exporting mutable module-level state to SDK consumers created hidden coupling and state leakage risk.
- **Added `--max-lines` validation** (per code review): Values < 1 are rejected with `process.exit(2)`. Removed the `maxLines=0` edge case.
- **Fixed `maxLines` nullish check** (flagged by Devin Review): Changed `if (_outputOptions.maxLines)` to `if (_outputOptions.maxLines != null)`.
- 163 tests passing, lint/typecheck clean.

## Review & Testing Checklist for Human

- [ ] **`--fields` UX for paginated responses**: With the heuristic removed, `--fields identifier,name` on a `{nfts: [...], next: "..."}` response returns `{}` (no matching top-level keys). Users must use `--fields nfts,next` to select wrapper keys. Verify this is the intended UX.
- [ ] **Manual E2E test**: Unit tests only cover `formatOutput` directly, not the Commander argv parsing pipeline. Verify with real commands:
  ```bash
  npx . collections get <slug> --fields name,collection --api-key $OPENSEA_API_KEY
  npx . nfts list-by-collection <slug> --fields identifier,name --max-lines 10 --api-key $OPENSEA_API_KEY
  npx . nfts list-by-collection <slug> --max-lines 0 --api-key $OPENSEA_API_KEY  # should error
  ```
- [ ] **Truncated output is not valid JSON** — `--max-lines` appends a `... (N more lines)` suffix. Worth considering whether this should be documented in `--help`.

### Notes
- Confidence: 🟢 HIGH — straightforward feature, all review feedback addressed, 163 tests passing, lint/typecheck clean
- Linear: [DIS-145](https://linear.app/opensea/issue/DIS-145/opensea-cli-add-output-truncation-and-field-selection)
- Session: https://app.devin.ai/sessions/ba1d7e1da75d459eaca2606b5bbc931e
- Requested by: @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
