### PR TITLE
chore: bump version to 0.4.2 for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "OpenSea CLI - Query the OpenSea API from the command line or programmatically",
   "main": "dist/index.js",


### PR DESCRIPTION
# chore: bump version to 0.4.2 for npm publish

## Summary

Bumps `package.json` version from `0.4.1` to `0.4.2`. The `v0.4.2` git tag and GitHub release already exist, but the npm publish [failed](https://github.com/ProjectOpenSea/opensea-cli/actions/runs/22688638822) because `package.json` was never updated from `0.4.1` — so npm rejected the publish with "You cannot publish over the previously published versions: 0.4.1."

This version includes the `User-Agent: opensea-cli/<version>` header on all HTTP requests, which is needed to track CLI usage in DataDog.

## Review & Testing Checklist for Human

- [ ] After merging, re-run the failed `v0.4.2` release workflow (or delete and re-create the `v0.4.2` release) to trigger the actual npm publish
- [ ] Verify the published package on npm contains the User-Agent header in the built `dist/cli.js` and `dist/index.js`

### Notes
- Requested by: @ckorhonen
- [Devin Session](https://app.devin.ai/sessions/7836d658ecf3454480ab541bf3154b18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-cli/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
