### PR TITLE
Document SDK timeout and verbose configuration options

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -17,6 +17,8 @@ const client = new OpenSeaCLI({ apiKey: process.env.OPENSEA_API_KEY })
 | `apiKey` | `string` | *required* | OpenSea API key |
 | `baseUrl` | `string` | `https://api.opensea.io` | API base URL override |
 | `chain` | `string` | `"ethereum"` | Default chain |
+| `timeout` | `number` | `30000` | Request timeout in milliseconds |
+| `verbose` | `boolean` | `false` | Log request/response to stderr |
 
 ## Collections
 


### PR DESCRIPTION
## What

Document the `timeout` and `verbose` options in the SDK Configuration table.

## Why

Both options are part of `OpenSeaClientConfig` and are supported by the SDK, but were missing from the configuration documentation.

* `timeout` controls the request timeout and defaults to `30000` ms.
* `verbose` enables request/response logging and defaults to `false`.

No runtime behavior is changed.
